### PR TITLE
Allow GpChatResponse be triggered by files not in the chat folder

### DIFF
--- a/lua/gp.lua
+++ b/lua/gp.lua
@@ -809,6 +809,13 @@ M.cmd.ChatRespond = function()
 	-- get all lines
 	local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 
+	-- check if file looks like a chat file
+	local file_name = vim.api.nvim_buf_get_name(buf)
+	if not (lines[1]:match("^# topic: ") and lines[3]:match("^- model: ")) then
+		print("File " .. file_name .. " does not look like a chat file")
+		return
+	end
+
 	-- headers are fields before first ---
 	local headers = {}
 	local headers_done = false

--- a/lua/gp.lua
+++ b/lua/gp.lua
@@ -784,13 +784,6 @@ end
 M.cmd.ChatRespond = function()
 	local buf = vim.api.nvim_get_current_buf()
 
-	-- check if file is in the chat dir
-	local file_name = vim.api.nvim_buf_get_name(buf)
-	if not string.match(file_name, M.config.chat_dir) then
-		print("File " .. file_name .. " is not in chat dir")
-		return
-	end
-
 	-- get all lines
 	local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 


### PR DESCRIPTION
Hi, I have a scratch file fold and I want to put the chat files along with my other scratch files.

So I hope this GpChatResponse can be triggered outside the chat fold.

For example, in my usecase, the file is `/Users/lintao/.cache/nvim/scratch.nvim/192326-230723.gp.md`

![show](https://github.com/Robitx/gp.nvim/assets/95092244/c1bac5b7-cd67-4edf-985f-bfe8f9dd832f)
