### PR TITLE
Add one new secure way to get  the api key. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Gp.nvim provides you ChatGPT like sessions and instructable text/code operations
 
 ## Goals and Features
 
-The goal is to extend Neovim with the **power of GPT models in a simple unobtrusive extensible way.**
+The goal is to extend Neovim with the **power of GPT models in a simple unobtrusive extensible way.**  
 Trying to keep things as native as possible - reusing and integrating well with the natural features of (Neo)vim.
 
 - **Streaming responses**
@@ -40,13 +40,13 @@ Trying to keep things as native as possible - reusing and integrating well with 
   - templating mechanism to combine user instructions, selections etc into the gpt query
   - multimodal - same command works for normal/insert mode, with selection or a range
   - many possible output targets - rewrite, prepend, append, new buffer, popup
-  - non interactive command mode available for common repetitive tasks implementable as simple hooks
-    (explain something in a popup window, write unit tests for selected code into a new buffer,
+  - non interactive command mode available for common repetitive tasks implementable as simple hooks  
+    (explain something in a popup window, write unit tests for selected code into a new buffer,  
     finish selected code based on comments in it, etc.)
-  - custom instructions per repository with `.gp.md` file
+  - custom instructions per repository with `.gp.md` file  
     (instruct gpt to generate code using certain libs, packages, conventions and so on)
 - **Speech to text support**
-  - a mouth is 2-4x faster than fingers when it comes to outputting words - use it where it makes sense
+  - a mouth is 2-4x faster than fingers when it comes to outputting words - use it where it makes sense  
     (dicating comments and notes, asking gpt questions, giving instructions for code operations, ..)
 
 ## Install
@@ -85,14 +85,14 @@ use({
 
 ### 2. OpenAI API key
 
-Make sure you have OpenAI API key. [Get one here](https://platform.openai.com/account/api-keys)
-and use it in the [config](#4-configuration) (or **setup env `OPENAI_API_KEY`** or use one system command which returned the API key).
+Make sure you have OpenAI API key. [Get one here](https://platform.openai.com/account/api-keys) and use it in the [config](#4-configuration). Also consider setting up [usage limits](https://platform.openai.com/account/billing/limits) so you won't get suprised at the end of the month.
 
-There are two options to set OpenAI API key:
-1. use `openai_api_key`: it is a string. You can set the key directly (not recommended) or use env `OPENAI_API_KEY`.
-2. use `openai_api_key_cmd`: it is highly secure when you use some password managers like [1Password](https://1password.com/) or [Bitwarden](https://bitwarden.com/).
-
-Also consider setting up [usage limits](https://platform.openai.com/account/billing/limits) so you won't get suprised at the end of the month.
+The OpenAI API key can be passed to the plugin in multiple ways:
+- set up env variable `OPENAI_API_KEY` which the plugin tries to read by default and fills into `openai_api_key` automatically
+- set up any env name you want and read it via `openai_api_key = os.getenv("env_name.."),`
+- insert the key directly into the config `openai_api_key: "sk-...",` (least safe from security standpoint)
+- read the key from a file `openai_api_key = { "cat", "path_to/openai_api_key" },`
+- use cli command from your password manager (like [1Password](https://1password.com/) or [Bitwarden](https://bitwarden.com/)) by passing a list (command + attributes) into the config field `openai_api_key = { "bw", "get", "password", "OPENAI_API_KEY" },`, this is the most secure way, but managers are often take a second or two (Gp runs the command asynchronously to avoid blocking neovim)
 
 ### 3. Dependencies
 
@@ -118,15 +118,15 @@ https://github.com/Robitx/gp.nvim/blob/84a39ce557ac771b42c38e9b9d211ec3f3bd32cc/
 
 - Have ChatGPT experience directly in neovim:
 
-  - `:GpChatNew` - open fresh chat in the current window
+  - `:GpChatNew` - open fresh chat in the current window  
     (either empty or with the visual selection or specified range as a context)
   - `:GpChatPaste` - paste the selection or specified range to the latest chat
     (simplifies adding code from multiple files into a single chat buffer)
-  - `:GpChatToggle` - open chat in toggleable popup window
+  - `:GpChatToggle` - open chat in toggleable popup window  
     (the last active chat or a fresh one with selection or a range as a context)
   - `:GpChatFinder` - open a dialog to search through chats
   - `:GpChatRespond` - request new gpt response for the current chat
-  - `:GpChatRespond N` - request new gpt response with only last N messages as a context
+  - `:GpChatRespond N` - request new gpt response with only last N messages as a context  
     (using everything from the end up to Nth instance of `🗨:..` => `N=1` is like asking a question in a new chat)
   - `:GpChatDelete` - delete the current chat
 
@@ -143,7 +143,7 @@ https://github.com/Robitx/gp.nvim/blob/84a39ce557ac771b42c38e9b9d211ec3f3bd32cc/
   - `:GpVnew` - answers into new vertical split window
   - `:GpTabnew` - answers into new tab
   - `:GpPopup` - answers into pop up window
-  - `:GpImplement` - default example hook command for finishing the code
+  - `:GpImplement` - default example hook command for finishing the code  
     based on comments provided in visual selection or specified range
 
   all these command work either:
@@ -169,7 +169,7 @@ https://github.com/Robitx/gp.nvim/blob/84a39ce557ac771b42c38e9b9d211ec3f3bd32cc/
 
 - Voice commands transcribed by Whisper API:
   - `:GpWhisper` - transcription replaces the current line, visual selection or range in the current buffer (use your mouth to ask a question in a chat buffer instead of writing it by hand, dictate some comments for the code, notes or even your next novel)  
-for the rest of the whisper commands, the transcription is used as an editable prompt for the equivalent non whisper command (`GpWhisperRewrite` dictates instructions for `GpRewrite` etc.):
+    for the rest of the whisper commands, the transcription is used as an editable prompt for the equivalent non whisper command (`GpWhisperRewrite` dictates instructions for `GpRewrite` etc.):
   - `:GpWhisperRewrite` - answer replaces the current line, visual selection or range
   - `:GpWhisperAppend` - answers after the current line, visual selection or range
   - `:GpWhisperPrepend` - answers before the current line, selection or range
@@ -666,7 +666,7 @@ The raw plugin text editing method `Prompt` has seven aprameters:
 - `prompt`
   - string used similarly as bash/zsh prompt in terminal, when plugin asks for user command to gpt.
   - if `nil`, user is not asked to provide input (for specific predefined commands - document this, explain that, write tests ..)
-  - simple `🤖 ~ ` might be used or you could use different msg to convey info about the method which is called
+  - simple `🤖 ~ ` might be used or you could use different msg to convey info about the method which is called  
     (`🤖 rewrite ~`, `🤖 popup ~`, `🤖 enew ~`, `🤖 inline ~`, etc.)
 - `model`
   - see [gpt model overview](https://platform.openai.com/docs/models/overview)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Gp.nvim provides you ChatGPT like sessions and instructable text/code operations
 
 ## Goals and Features
 
-The goal is to extend Neovim with the **power of GPT models in a simple unobtrusive extensible way.**  
+The goal is to extend Neovim with the **power of GPT models in a simple unobtrusive extensible way.**
 Trying to keep things as native as possible - reusing and integrating well with the natural features of (Neo)vim.
 
 - **Streaming responses**
@@ -40,13 +40,13 @@ Trying to keep things as native as possible - reusing and integrating well with 
   - templating mechanism to combine user instructions, selections etc into the gpt query
   - multimodal - same command works for normal/insert mode, with selection or a range
   - many possible output targets - rewrite, prepend, append, new buffer, popup
-  - non interactive command mode available for common repetitive tasks implementable as simple hooks  
-    (explain something in a popup window, write unit tests for selected code into a new buffer,  
+  - non interactive command mode available for common repetitive tasks implementable as simple hooks
+    (explain something in a popup window, write unit tests for selected code into a new buffer,
     finish selected code based on comments in it, etc.)
-  - custom instructions per repository with `.gp.md` file  
+  - custom instructions per repository with `.gp.md` file
     (instruct gpt to generate code using certain libs, packages, conventions and so on)
 - **Speech to text support**
-  - a mouth is 2-4x faster than fingers when it comes to outputting words - use it where it makes sense  
+  - a mouth is 2-4x faster than fingers when it comes to outputting words - use it where it makes sense
     (dicating comments and notes, asking gpt questions, giving instructions for code operations, ..)
 
 ## Install
@@ -86,7 +86,11 @@ use({
 ### 2. OpenAI API key
 
 Make sure you have OpenAI API key. [Get one here](https://platform.openai.com/account/api-keys)
-and use it in the [config](#4-configuration) (or **setup env `OPENAI_API_KEY`**).
+and use it in the [config](#4-configuration) (or **setup env `OPENAI_API_KEY`** or use one system command which returned the API key).
+
+There are two options to set OpenAI API key:
+1. use `openai_api_key`: it is a string. You can set the key directly (not recommended) or use env `OPENAI_API_KEY`.
+2. use `openai_api_key_cmd`: it is highly secure when you use some password managers like [1Password](https://1password.com/) or [Bitwarden](https://bitwarden.com/).
 
 Also consider setting up [usage limits](https://platform.openai.com/account/billing/limits) so you won't get suprised at the end of the month.
 
@@ -114,15 +118,15 @@ https://github.com/Robitx/gp.nvim/blob/84a39ce557ac771b42c38e9b9d211ec3f3bd32cc/
 
 - Have ChatGPT experience directly in neovim:
 
-  - `:GpChatNew` - open fresh chat in the current window  
+  - `:GpChatNew` - open fresh chat in the current window
     (either empty or with the visual selection or specified range as a context)
   - `:GpChatPaste` - paste the selection or specified range to the latest chat
     (simplifies adding code from multiple files into a single chat buffer)
-  - `:GpChatToggle` - open chat in toggleable popup window  
+  - `:GpChatToggle` - open chat in toggleable popup window
     (the last active chat or a fresh one with selection or a range as a context)
   - `:GpChatFinder` - open a dialog to search through chats
   - `:GpChatRespond` - request new gpt response for the current chat
-  - `:GpChatRespond N` - request new gpt response with only last N messages as a context  
+  - `:GpChatRespond N` - request new gpt response with only last N messages as a context
     (using everything from the end up to Nth instance of `🗨:..` => `N=1` is like asking a question in a new chat)
   - `:GpChatDelete` - delete the current chat
 
@@ -139,7 +143,7 @@ https://github.com/Robitx/gp.nvim/blob/84a39ce557ac771b42c38e9b9d211ec3f3bd32cc/
   - `:GpVnew` - answers into new vertical split window
   - `:GpTabnew` - answers into new tab
   - `:GpPopup` - answers into pop up window
-  - `:GpImplement` - default example hook command for finishing the code  
+  - `:GpImplement` - default example hook command for finishing the code
     based on comments provided in visual selection or specified range
 
   all these command work either:
@@ -661,7 +665,7 @@ The raw plugin text editing method `Prompt` has seven aprameters:
 - `prompt`
   - string used similarly as bash/zsh prompt in terminal, when plugin asks for user command to gpt.
   - if `nil`, user is not asked to provide input (for specific predefined commands - document this, explain that, write tests ..)
-  - simple `🤖 ~ ` might be used or you could use different msg to convey info about the method which is called  
+  - simple `🤖 ~ ` might be used or you could use different msg to convey info about the method which is called
     (`🤖 rewrite ~`, `🤖 popup ~`, `🤖 enew ~`, `🤖 inline ~`, etc.)
 - `model`
   - see [gpt model overview](https://platform.openai.com/docs/models/overview)

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -8,6 +8,7 @@
 local config = {
 	-- required openai api key
 	openai_api_key = os.getenv("OPENAI_API_KEY"),
+	openai_api_key_cmd = "",
 	-- api endpoint (you can change this to azure endpoint)
 	openai_api_endpoint = "https://api.openai.com/v1/chat/completions",
 	-- openai_api_endpoint = "https://$URL.openai.azure.com/openai/deployments/{{model}}/chat/completions?api-version=2023-03-15-preview",

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -6,10 +6,12 @@
 --------------------------------------------------------------------------------
 
 local config = {
-	-- required openai api key
+	-- required openai api key (string or table with command and arguments)
+	-- openai_api_key = { "cat", "path_to/openai_api_key" },
+	-- openai_api_key = { "bw", "get", "password", "OPENAI_API_KEY" },
+	-- openai_api_key: "sk-...",
+	-- openai_api_key = os.getenv("env_name.."),
 	openai_api_key = os.getenv("OPENAI_API_KEY"),
-	-- openai api key from cmd, only works without openai_api_key
-	openai_api_key_cmd = "",
 	-- api endpoint (you can change this to azure endpoint)
 	openai_api_endpoint = "https://api.openai.com/v1/chat/completions",
 	-- openai_api_endpoint = "https://$URL.openai.azure.com/openai/deployments/{{model}}/chat/completions?api-version=2023-03-15-preview",

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -8,6 +8,7 @@
 local config = {
 	-- required openai api key
 	openai_api_key = os.getenv("OPENAI_API_KEY"),
+	-- openai api key from cmd, only works without openai_api_key
 	openai_api_key_cmd = "",
 	-- api endpoint (you can change this to azure endpoint)
 	openai_api_endpoint = "https://api.openai.com/v1/chat/completions",

--- a/lua/gp/health.lua
+++ b/lua/gp/health.lua
@@ -18,10 +18,14 @@ function M.check()
 		---@diagnostic disable-next-line: undefined-field
 		local api_key = gp.config.openai_api_key
 
-		if api_key == nil or api_key == "" then
-			vim.health.error("require('gp').setup({openai_api_key: ???}) is not set: " .. vim.inspect(api_key))
-		else
+		if type(api_key) == "table" then
+			vim.health.error(
+				"require('gp').setup({openai_api_key: ???}) is still an unresolved command: " .. vim.inspect(api_key)
+			)
+		elseif api_key and string.match(api_key, "%S") then
 			vim.health.ok("config.openai_api_key is set")
+		else
+			vim.health.error("require('gp').setup({openai_api_key: ???}) is not set: " .. vim.inspect(api_key))
 		end
 	end
 

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -655,39 +655,6 @@ M.append_selection = function(params, origin_buf, target_buf)
 	vim.api.nvim_buf_set_lines(target_buf, last_content_line, -1, false, lines)
 end
 
-local split_command = function(command)
-	local cmd = {}
-	for word in command:gmatch("%S+") do
-		table.insert(cmd, word)
-	end
-	return cmd
-end
-
-local job = require("plenary.job")
-
---- load openai api key in asynchronous way
----@param command string the command whose result is the api key
----@param _config table the M.config table
-local function load_openai_key_by_cmd(command, _config)
-	local cmd = split_command(command)
-	job:new({
-		command = cmd[1],
-		args = vim.list_slice(cmd, 2, #cmd),
-		on_exit = function(j, exit_code)
-			if exit_code ~= 0 then
-				M.warning("gp.nvim config.openai_api_key_cmd need return a value")
-				return
-			end
-			local value = j:result()[1]:gsub("%s+$", "")
-			if value ~= nil and value ~= "" then
-				M.warning("gp.nvim config.openai_api_key_cmd need return a value")
-			else
-				_config.openai_api_key = value
-			end
-		end,
-	}):start()
-end
-
 -- setup function
 M._setup_called = false
 ---@param opts table | nil # table with options
@@ -859,15 +826,59 @@ M.setup = function(opts)
 		M.error("curl is not installed, run :checkhealth gp")
 	end
 
-	local api_key_check = function(key)
-		return key == nil or key == ""
+	if type(M.config.openai_api_key) == "table" then
+		---@diagnostic disable-next-line: param-type-mismatch
+		local copy = vim.deepcopy(M.config.openai_api_key)
+		---@diagnostic disable-next-line: param-type-mismatch
+		local cmd = table.remove(copy, 1)
+		local args = copy
+		---@diagnostic disable-next-line: param-type-mismatch
+		_H.process(nil, cmd, args, function(code, signal, stdout_data, stderr_data)
+			if code == 0 then
+				local content = stdout_data:match("^%s*(.-)%s*$")
+				if not string.match(content, "%S") then
+					M.warning(
+						"response from the config.openai_api_key command "
+							.. vim.inspect(M.config.openai_api_key)
+							.. " is empty"
+					)
+					return
+				end
+				M.config.openai_api_key = content
+			else
+				M.warning(
+					"config.openai_api_key command "
+						.. vim.inspect(M.config.openai_api_key)
+						.. " to retrieve openai_api_key failed:\ncode: "
+						.. code
+						.. ", signal: "
+						.. signal
+						.. "\nstdout: "
+						.. stdout_data
+						.. "\nstderr: "
+						.. stderr_data
+				)
+			end
+		end)
+	else
+		M.valid_api_key()
 	end
-	if api_key_check(M.config.openai_api_key) and api_key_check(M.config.openai_api_key_cmd) then
-		M.warning("gp.nvim config.openai_api_key is not set, run :checkhealth gp")
+end
+
+M.valid_api_key = function()
+	local api_key = M.config.openai_api_key
+
+	if type(api_key) == "table" then
+		M.error("openai_api_key is still an unresolved command: " .. vim.inspect(api_key))
+		return false
 	end
-	if api_key_check(M.config.openai_api_key) then
-		load_openai_key_by_cmd(M.config.openai_api_key_cmd, M.config)
+
+	if api_key and string.match(api_key, "%S") then
+		return true
 	end
+
+	M.error("config.openai_api_key is not set: " .. vim.inspect(api_key) .. " run :checkhealth gp")
+	return false
 end
 
 M.refresh_state = function()
@@ -1053,9 +1064,7 @@ M.query = function(buf, payload, handler, on_exit)
 		return
 	end
 
-	-- make sure openai_api_key is set
-	if M.config.openai_api_key == nil or M.config.openai_api_key == "" then
-		M.error("config.openai_api_key is not set, run :checkhealth gp")
+	if not M.valid_api_key() then
 		return
 	end
 
@@ -1780,9 +1789,7 @@ M.chat_respond = function(params)
 	local buf = vim.api.nvim_get_current_buf()
 	local win = vim.api.nvim_get_current_win()
 
-	-- make sure openai_api_key is set
-	if M.config.openai_api_key == nil or M.config.openai_api_key == "" then
-		M.error("config.openai_api_key is not set, run :checkhealth gp")
+	if not M.valid_api_key() then
 		return
 	end
 
@@ -2784,9 +2791,7 @@ M.Whisper = function(callback)
 		},
 	}
 
-	-- make sure openai_api_key is set
-	if M.config.openai_api_key == nil or M.config.openai_api_key == "" then
-		M.error("config.openai_api_key is not set, run :checkhealth gp")
+	if not M.valid_api_key() then
 		return
 	end
 
@@ -3008,6 +3013,10 @@ M.cmd.Image = function(params)
 end
 
 function M.generate_image(prompt, model, quality, style, size)
+	if not M.valid_api_key() then
+		return
+	end
+
 	local cmd = "curl"
 	local payload = {
 		model = model,

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -650,6 +650,10 @@ local split_command = function(command)
 end
 
 local job = require("plenary.job")
+
+--- load openai api key in asynchronous way
+---@param command string the command whose result is the api key
+---@param _config table the M.config table
 local function load_openai_key_by_cmd(command, _config)
 	local cmd = split_command(command)
 	job:new({
@@ -850,9 +854,6 @@ M.setup = function(opts)
 	if api_key_check(M.config.openai_api_key) then
 		load_openai_key_by_cmd(M.config.openai_api_key_cmd, M.config)
 	end
-	-- if M.config.openai_api_key == nil or M.config.openai_api_key == "" then
-	-- 	M.warning("gp.nvim config.openai_api_key is not set, run :checkhealth gp")
-	-- end
 end
 
 M.refresh_state = function()


### PR DESCRIPTION
Add `env` is also unsafe. 
If users use password managers like 1Password or Bitwarden, they can get the api key by running some system command. 
For example `bw get password chatgpt-api-key`.

This pr adds one new config option to supplement methods getting `the KEY`.