### PR TITLE
fix: proper number formatting for sox (resolve: Robitx/gp.nvim#77)

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2828,6 +2828,7 @@ M.Whisper = function(callback)
 		local cmd = "cd "
 			.. M.config.whisper_dir
 			.. " && "
+			.. "export LC_NUMERIC='C' && "
 			-- normalize volume to -3dB
 			.. "sox --norm=-3 rec.wav norm.wav && "
 			-- get RMS level dB * silence threshold


### PR DESCRIPTION
Makes sure number formatting of `sox`'s output uses decimal point on all systems regardless of their locale by setting `LC_NUMERIC='C'`.