### PR TITLE
chore: use `InsertLeave` instead of `TextChangedI`

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1356,8 +1356,8 @@ M.prep_md = function(buf)
 	vim.api.nvim_command("setlocal noswapfile")
 	-- better text wrapping
 	vim.api.nvim_command("setlocal wrap linebreak")
-	-- auto save on TextChanged, TextChangedI
-	vim.api.nvim_command("autocmd TextChanged,TextChangedI <buffer=" .. buf .. "> silent! write")
+	-- auto save on TextChanged, InsertLeave
+	vim.api.nvim_command("autocmd TextChanged,InsertLeave <buffer=" .. buf .. "> silent! write")
 
 	-- register shortcuts local to this buffer
 	buf = buf or vim.api.nvim_get_current_buf()
@@ -2252,7 +2252,7 @@ M.cmd.ChatFinder = function()
 	end, gid)
 
 	-- when command buffer is written, execute it
-	_H.autocmd({ "TextChanged", "TextChangedI", "TextChangedP", "TextChangedT" }, { command_buf }, function()
+	_H.autocmd({ "TextChanged", "InsertLeave", "TextChangedP", "TextChangedT" }, { command_buf }, function()
 		vim.api.nvim_win_set_cursor(picker_win, { 1, 0 })
 		refresh_picker()
 	end, gid)

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2252,7 +2252,7 @@ M.cmd.ChatFinder = function()
 	end, gid)
 
 	-- when command buffer is written, execute it
-	_H.autocmd({ "TextChanged", "InsertLeave", "TextChangedP", "TextChangedT" }, { command_buf }, function()
+	_H.autocmd({ "TextChanged", "TextChangedI", "TextChangedP", "TextChangedT" }, { command_buf }, function()
 		vim.api.nvim_win_set_cursor(picker_win, { 1, 0 })
 		refresh_picker()
 	end, gid)


### PR DESCRIPTION
hey there!

thank you for this superb plugin, it's extremely useful!

i had a small issue with undoing changes done in insert mode and took
few minutes to fix it.

Not sure if it's the best way to fix it, and i haven't thoroughly tested
all features (there're a lot!).

`gp.nvim` has autosave feature which is triggered by few events, one of which is `TextChangedI`.

when typing text in insert mode, any change done there saves the file. This grows the `:undolist` too much, because any change in insert mode is saved and treated as a separate change.

Normally to undo the last change, you would press `u` once in normal mode. But with autosave triggered by `TextChangedI`, you have to press `u` multiple times, for each change.

using `InsertLeave` instead of `TextChangedI` avoids such problem.

For comparison, consider scenario:

1. open neovim
2. run `:GpChatNew`
3. go to insert mode and type `123`
4. leave insert mode
5. run `:undolist`

on my setup it shows:

```
number changes  when               saved
     4       4  2 seconds ago
```

doing the equivalent when `InsertLeave` is used instead of `TextChangedI`:

```
number changes  when               saved
     1       1  2 seconds ago        1
```

this is much better, because now you can undo the last change with single `u` press!
