### PR TITLE
Add option to set whisper recording command

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -179,8 +179,6 @@ local config = {
 	-- decrease this number to pick up only louder sounds as possible speech
 	-- you can disable silence trimming by setting this a very high number (like 1000.0)
 	whisper_silence = "1.75",
-	-- whisper max recording time (mm:ss)
-	whisper_max_time = "05:00",
 	-- whisper tempo (1.0 is normal speed)
 	whisper_tempo = "1.75",
 	-- The language of the input audio, in ISO-639-1 format.

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -185,6 +185,8 @@ local config = {
 	whisper_tempo = "1.75",
 	-- The language of the input audio, in ISO-639-1 format.
 	whisper_language = "en",
+	-- Override command to use for recording (does not support options)
+	whisper_rec_cmd = nil,
 
 	-- image generation settings
 	-- image prompt prefix for asking user for input (supports {{agent}} template variable)

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -183,7 +183,16 @@ local config = {
 	whisper_tempo = "1.75",
 	-- The language of the input audio, in ISO-639-1 format.
 	whisper_language = "en",
-	-- Override command to use for recording (does not support options)
+	-- command to use for recording can be nil (unset) for automatic selection
+	-- string ("sox", "arecord", "ffmpeg") or table with command and arguments:
+	-- sox is the most universal, but can have start/end cropping issues caused by latency
+	-- arecord is linux only, but has no cropping issues and is faster
+	-- ffmpeg in the default configuration is macos only, but can be used on any platform
+	-- (see https://trac.ffmpeg.org/wiki/Capture/Desktop for more info)
+	-- below is the default configuration for all three commands:
+	-- whisper_rec_cmd = {"sox", "-c", "1", "--buffer", "32", "-d", "rec.wav", "trim", "0", "60:00"},
+	-- whisper_rec_cmd = {"arecord", "-c", "1", "-f", "S16_LE", "-r", "48000", "-d", "3600", "rec.wav"},
+	-- whisper_rec_cmd = {"ffmpeg", "-y", "-f", "avfoundation", "-i", ":0", "-t", "3600", "rec.wav"},
 	whisper_rec_cmd = nil,
 
 	-- image generation settings

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -17,7 +17,7 @@ local deprecated = {
 	chat_system_prompt = "`chat_system_prompt`\n" .. switch_to_agent,
 	command_prompt_prefix = "`command_prompt_prefix`\nPlease use `command_prompt_prefix_template`"
 		.. " with support for \n`{{agent}}` variable so you know which agent is currently active",
-	whisper_max_time = "`whisper_max_time`\nPlease use fully cusomizable `whisper_rec_cmd`",
+	whisper_max_time = "`whisper_max_time`\nPlease use fully customizable `whisper_rec_cmd`",
 }
 
 --------------------------------------------------------------------------------

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2990,7 +2990,7 @@ M.Whisper = function(callback)
 		cmd = rec_options[rec_cmd]
 	else
 		M.error(string.format("Whisper got invalid recording command: %s", rec_cmd))
-        close()
+		close()
 		return
 	end
 	for i, v in ipairs(cmd.opts) do

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2968,16 +2968,24 @@ M.Whisper = function(callback)
 		end)
 	end
 
-	local rec_cmd = "sox"
-	if vim.fn.executable("ffmpeg") == 1 then
-		local devices = vim.fn.system("ffmpeg -devices -v quiet | grep -i avfoundation | wc -l")
-		devices = string.gsub(devices, "^%s*(.-)%s*$", "%1")
-		if devices == "1" then
-			rec_cmd = "ffmpeg"
+	local rec_cmd = M.config.whisper_rec_cmd
+	-- if rec_cmd not set explicitly, try to autodetect
+	if not rec_cmd then
+		rec_cmd = "sox"
+		if vim.fn.executable("ffmpeg") == 1 then
+			local devices = vim.fn.system("ffmpeg -devices -v quiet | grep -i avfoundation | wc -l")
+			devices = string.gsub(devices, "^%s*(.-)%s*$", "%1")
+			if devices == "1" then
+				rec_cmd = "ffmpeg"
+			end
+		end
+		if vim.fn.executable("arecord") == 1 then
+			rec_cmd = "arecord"
 		end
 	end
-	if vim.fn.executable("arecord") == 1 then
-		rec_cmd = "arecord"
+	if not rec_options[rec_cmd] then
+		M.error(string.format("Whisper got invalid recording command: %s", rec_cmd))
+		return
 	end
 
 	local cmd = rec_options[rec_cmd]

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -17,6 +17,7 @@ local deprecated = {
 	chat_system_prompt = "`chat_system_prompt`\n" .. switch_to_agent,
 	command_prompt_prefix = "`command_prompt_prefix`\nPlease use `command_prompt_prefix_template`"
 		.. " with support for \n`{{agent}}` variable so you know which agent is currently active",
+	whisper_max_time = "`whisper_max_time`\nPlease use fully cusomizable `whisper_rec_cmd`",
 }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Hello and thanks for the plugin! I had a little issue getting whisper to work, so submitting a fix your consideration.

This PR adds a way to manually specify in the config which command (`sox`, `ffmpeg`, or `arecord`) should be used for recording for commands like `GpWhisper`. E.g. use it in `.setup()` like `whisper_rec_cmd = 'sox'`.

I had an issue trying to use `GpWhisper`, where the output would always be just "you". I found the recordings, `rec.wav`, were always the correct length, but only silence. I think the problem is the options to `ffmpeg` select audio input device `:0`, which doesn't work in my case. Modifying `gp/init.lua` to always choose `rec_cmd = "sox"` works fine for me. There's probably some way to look into the audio input devices more and improve the autodetection, but I'm not sure how to do that well, and thinking that this may not be a common issue anyway.

<details>
<summary>Debugging my issue with audio devices...</summary>

Here's some info from a terminal session of me figuring out what was going on, if it helps.

## Screenshot with notes

<img width="603" alt="tmux" src="https://github.com/Robitx/gp.nvim/assets/17808749/6ef66523-17f6-49d9-b688-5c52fff149ee">

## Raw text output

```txt
/tmp/gp_whisper ❯ ffmpeg -devices -v quiet | grep -i avfoundation | wc -l                                                                                                                                                    11:47:11
       1
/tmp/gp_whisper ❯ ffmpeg -devices -v quiet | grep -i avfoundation                                                                                                                                                            11:50:53
 D  avfoundation    AVFoundation input device
/tmp/gp_whisper ❯ ffmpeg -devices -v quiet                                                                                                                                                                                   11:50:59
Devices:
 D. = Demuxing supported
 .E = Muxing supported
 --
  E audiotoolbox    AudioToolbox output device
 D  avfoundation    AVFoundation input device
 D  lavfi           Libavfilter virtual input device
  E sdl,sdl2        SDL2 output device
 D  x11grab         X11 screen capture, using XCB
/tmp/gp_whisper ❯ ffmpeg -f avfoundation -list_devices true -i ""                                                                                                                                                            11:51:10
ffmpeg version 6.0 Copyright (c) 2000-2023 the FFmpeg developers
  built with Apple clang version 14.0.3 (clang-1403.0.22.14.1)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/6.0_1 --enable-shared --enable-pthreads --enable-version3 --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libaribb24 --enable-libbluray --enable-libdav1d --enable-libjxl --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librist --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libsvtav1 --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libspeex --enable-libsoxr --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack --enable-videotoolbox --enable-audiotoolbox
  libavutil      58.  2.100 / 58.  2.100
  libavcodec     60.  3.100 / 60.  3.100
  libavformat    60.  3.100 / 60.  3.100
  libavdevice    60.  1.100 / 60.  1.100
  libavfilter     9.  3.100 /  9.  3.100
  libswscale      7.  1.100 /  7.  1.100
  libswresample   4. 10.100 /  4. 10.100
  libpostproc    57.  1.100 / 57.  1.100
[AVFoundation indev @ 0x7fe4d6f04a00] AVFoundation video devices:
[AVFoundation indev @ 0x7fe4d6f04a00] [0] FaceTime HD Camera (Built-in)
[AVFoundation indev @ 0x7fe4d6f04a00] [1] LG UltraFine Display Camera
[AVFoundation indev @ 0x7fe4d6f04a00] [2] Snap Camera
[AVFoundation indev @ 0x7fe4d6f04a00] [3] Capture screen 0
[AVFoundation indev @ 0x7fe4d6f04a00] [4] Capture screen 1
[AVFoundation indev @ 0x7fe4d6f04a00] [5] Capture screen 2
[AVFoundation indev @ 0x7fe4d6f04a00] AVFoundation audio devices:
[AVFoundation indev @ 0x7fe4d6f04a00] [0] ZoomAudioDevice
[AVFoundation indev @ 0x7fe4d6f04a00] [1] MacBook Pro Microphone
[AVFoundation indev @ 0x7fe4d6f04a00] [2] LG UltraFine Display Audio
```

</details>


### Screenshot of new error message in action

If you pick an invalid value, you'll find out when you try to record:

![tmux](https://github.com/Robitx/gp.nvim/assets/17808749/a3ce951e-32c7-4c42-8366-4568c58c8f2b)
