### PR TITLE
feat(config): allow turning off G in GpChats

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -121,6 +121,8 @@ local config = {
 	chat_finder_pattern = "topic ",
 	-- if true, finished ChatResponder won't move the cursor to the end of the buffer
 	chat_free_cursor = false,
+	-- control whether to type G whenever the chat buffer is focused
+	jump_to_bottom = true,
 
 	-- how to display GpChatToggle or GpContext: popup / split / vsplit / tabnew
 	toggle_target = "vsplit",

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1366,7 +1366,9 @@ M.prep_md = function(buf)
 	buf = buf or vim.api.nvim_get_current_buf()
 
 	-- move cursor to a new line at the end of the file
-	M._H.feedkeys("G", "x")
+	if M.config.jump_to_bottom then
+		M._H.feedkeys("G", "x")
+	end
 
 	-- ensure normal mode
 	vim.api.nvim_command("stopinsert")


### PR DESCRIPTION
I had some trouble with the behavior of always jumping to the bottom of chats. For long chats, switching to the chat buffer would always lose my scroll place and go to the bottom. I can type `G` myself easily enough, so this PR adds an option to disable this behavior and retain the old scroll place.

I think it's worth making this the default (`jump_to_bottom = false`) or just removing the `M._H.feedkeys("G", "x")` call altogether and removing this flag, but for compatibility the current PR makes no changes to existing behavior. Let me know what you think!