### PR TITLE
Avoid needing user input on fresh installations

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -887,7 +887,10 @@ end
 M.refresh_state = function()
 	local state_file = M.config.state_dir .. "/state.json"
 
-	local state = M.file_to_table(state_file) or {}
+	local state = {}
+	if vim.fn.filereadable(state_file) ~= 0 then
+		state = M.file_to_table(state_file) or {}
+	end
 
 	M._state.chat_agent = M._state.chat_agent or state.chat_agent or nil
 	if M._state.chat_agent == nil or not M.agents[M._state.chat_agent] then

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -531,7 +531,7 @@ end
 M._log = function(msg, kind, history)
 	vim.schedule(function()
 		vim.api.nvim_echo({
-			{ M._Name .. ": " .. msg .. "\n", kind },
+			{ M._Name .. ": " .. msg, kind },
 		}, history, {})
 	end)
 end


### PR DESCRIPTION
I noticed that the info-msgs on creating new directories always require user input (press enter) and that a warning pops up if the state file is not found. Both of these are annoying on fresh installations of the plugin (something I do a lot).

This PR fixes both of these issues, please have a look.