### PR TITLE
feat: add `config.chat_template` to be able to customize the chat file banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ use({
 })
 ```
 
+```lua
+-- vim-plug
+Plug 'robitx/gp.nvim'
+
+require("gp").setup()
+
+-- or setup with your own config (see Install > Configuration in Readme)
+-- require("gp").setup(config)
+
+-- shortcuts might be setup here (see Usage > Shortcuts in Readme)
+```
 ## 2. OpenAI API key
 
 Make sure you have OpenAI API key. [Get one here](https://platform.openai.com/account/api-keys) and use it in the [4. Configuration](#4-configuration). Also consider setting up [usage limits](https://platform.openai.com/account/billing/limits) so you won't get suprised at the end of the month.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 
 <!-- panvimdoc-ignore-end -->
 
+---
+
+> **Note:** This repository is a fork of the original [gp.nvim](https://github.com/Robitx/gp.nvim) plugin. It includes a few small improvements which you can find in the [GitHub compare page](https://github.com/Robitx/gp.nvim/compare/main...argshook:gp.nvim:main).
+
+> If you like this plugin, please share your love on the original repository: [gp.nvim](https://github.com/Robitx/gp.nvim)
+
+---
+
 <br>
 
 **ChatGPT like sessions, Instructable text/code operations, Speech to text and Image generation in your favorite editor.**
@@ -105,19 +113,20 @@ require("gp").setup()
 
 -- shortcuts might be setup here (see Usage > Shortcuts in Readme)
 ```
+
 ## 2. OpenAI API key
 
 Make sure you have OpenAI API key. [Get one here](https://platform.openai.com/account/api-keys) and use it in the [4. Configuration](#4-configuration). Also consider setting up [usage limits](https://platform.openai.com/account/billing/limits) so you won't get suprised at the end of the month.
 
 The OpenAI API key can be passed to the plugin in multiple ways:
 
-| Method                    | Example                                                        | Security Level      |
-| ------------------------- | -------------------------------------------------------------- | ------------------- |
-| hardcoded string          | `openai_api_key: "sk-...",`                                    | Low                 |
-| default env var           | set `OPENAI_API_KEY` environment variable in shell config      | Medium              |
-| custom env var            | `openai_api_key = os.getenv("CUSTOM_ENV_NAME"),`               | Medium              |
-| read from file            | `openai_api_key = { "cat", "path_to_api_key" },`               | Medium-High         |
-| password manager          | `openai_api_key = { "bw", "get", "password", "OAI_API_KEY" },` | High                |
+| Method           | Example                                                        | Security Level |
+| ---------------- | -------------------------------------------------------------- | -------------- |
+| hardcoded string | `openai_api_key: "sk-...",`                                    | Low            |
+| default env var  | set `OPENAI_API_KEY` environment variable in shell config      | Medium         |
+| custom env var   | `openai_api_key = os.getenv("CUSTOM_ENV_NAME"),`               | Medium         |
+| read from file   | `openai_api_key = { "cat", "path_to_api_key" },`               | Medium-High    |
+| password manager | `openai_api_key = { "bw", "get", "password", "OAI_API_KEY" },` | High           |
 
 If `openai_api_key` is a table, Gp runs it asynchronously to avoid blocking Neovim (password managers can take a second or two).
 

--- a/doc/gp.nvim.txt
+++ b/doc/gp.nvim.txt
@@ -1,4 +1,4 @@
-*gp.nvim.txt*           For NVIM v0.8.0          Last change: 2024 February 28
+*gp.nvim.txt*            For NVIM v0.8.0            Last change: 2024 March 26
 
 ==============================================================================
 Table of Contents                                  *gp.nvim-table-of-contents*
@@ -108,6 +108,18 @@ Snippets for your preferred package manager:
             -- shortcuts might be setup here (see Usage > Shortcuts in Readme)
         end,
     })
+<
+
+>lua
+    -- vim-plug
+    Plug 'robitx/gp.nvim'
+    
+    require("gp").setup()
+    
+    -- or setup with your own config (see Install > Configuration in Readme)
+    -- require("gp").setup(config)
+    
+    -- shortcuts might be setup here (see Usage > Shortcuts in Readme)
 <
 
 

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -40,7 +40,7 @@ local config = {
 			chat = true,
 			command = false,
 			-- string with model name or table with model name and parameters
-			model = { model = "gpt-4-1106-preview", temperature = 1.1, top_p = 1 },
+			model = { model = "gpt-4o", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
 			system_prompt = "You are a general AI assistant.\n\n"
 				.. "The user provided the additional info about how they would like you to respond:\n\n"
@@ -74,7 +74,7 @@ local config = {
 			chat = false,
 			command = true,
 			-- string with model name or table with model name and parameters
-			model = { model = "gpt-4-1106-preview", temperature = 0.8, top_p = 1 },
+			model = { model = "gpt-4o", temperature = 0.8, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
 			system_prompt = "You are an AI working as a code editor.\n\n"
 				.. "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n"

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -102,6 +102,20 @@ local config = {
 	-- just a static string is legacy and the [{{agent}}] element is added automatically
 	-- if you really want just a static string, make it a table with one element { "🤖:" }
 	chat_assistant_prefix = { "🤖:", "[{{agent}}]" },
+	-- The banner shown at the top of each chat file.
+	chat_template = [[
+# topic: ?
+
+- file: %s
+%s
+Write your queries after %s. Use `%s` or :%sChatRespond to generate a response.
+Response generation can be terminated by using `%s` or :%sChatStop command.
+Chats are saved automatically. To delete this chat, use `%s` or :%sChatDelete.
+Be cautious of very long chats. Start a fresh chat by using `%s` or :%sChatNew.
+
+---
+
+%s]],
 	-- chat topic generation prompt
 	chat_topic_gen_prompt = "Summarize the topic of our conversation above"
 		.. " in two or three words. Respond only with those words.",

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1675,7 +1675,7 @@ M.new_chat = function(params, model, system_prompt, toggle)
 	end
 
 	local template = string.format(
-		M.chat_template,
+		M.config.chat_template or M.chat_template,
 		string.match(filename, "([^/]+)$"),
 		model .. system_prompt,
 		M.config.chat_user_prefix,

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1573,6 +1573,8 @@ M.open_buf = function(file_name, target, kind, toggle)
 			-- read file into buffer and force write it
 			vim.api.nvim_command("silent 0read " .. file_name)
 			vim.api.nvim_command("silent file " .. file_name)
+			-- set the filetype to markdown
+			vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
 		else
 			-- move cursor to the beginning of the file and scroll to the end
 			M._H.feedkeys("ggG", "xn")

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1466,7 +1466,17 @@ M.prep_chat = function(buf, file_name)
 	-- make last.md a symlink to the last opened chat file
 	local last = M.config.chat_dir .. "/last.md"
 	if file_name ~= last then
-		os.execute("ln -sf " .. file_name .. " " .. last)
+		local check_command = "if [[ -L " .. last .. " || ! -e " .. last .. " ]]; then echo 'ok'; else echo 'fail'; fi"
+		local handle = io.popen(check_command)
+		local result = handle:read("*a")
+		handle:close()
+		
+		if result:find("ok") then
+			os.remove(last)
+			os.execute("ln -sf " .. file_name .. " " .. last)
+		else
+			print("Error: 'last.md' exists and is not a symbolic link.")
+		end
 	end
 end
 

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -622,12 +622,26 @@ M.repo_instructions = function()
 	return table.concat(lines, "\n")
 end
 
+local function get_git_root()
+	local handle = io.popen("git rev-parse --show-toplevel 2>/dev/null")
+	local result = handle:read("*a"):gsub("\n", "")
+	handle:close()
+	return result ~= "" and result or nil
+end
+
+local function get_relative_path(full_path, git_root)
+	return git_root and full_path:sub(#git_root + 2) or full_path
+end
+
 M.template_render = function(template, command, selection, filetype, filename)
+	local git_root = get_git_root()
+	local relative_filename = get_relative_path(filename, git_root)
+	
 	local key_value_pairs = {
 		["{{command}}"] = command,
 		["{{selection}}"] = selection,
 		["{{filetype}}"] = filetype,
-		["{{filename}}"] = filename,
+		["{{filename}}"] = relative_filename,
 	}
 	return _H.template_render(template, key_value_pairs)
 end

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2270,7 +2270,7 @@ M.cmd.ChatFinder = function()
 	end, gid)
 
 	-- when command buffer is written, execute it
-	_H.autocmd({ "TextChanged", "TextChangedI", "TextChangedP", "TextChangedT" }, { command_buf }, function()
+	_H.autocmd({ "TextChanged", "InsertLeave", "TextChangedP", "TextChangedT" }, { command_buf }, function()
 		vim.api.nvim_win_set_cursor(picker_win, { 1, 0 })
 		refresh_picker()
 	end, gid)

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2221,10 +2221,12 @@ M.cmd.ChatFinder = function()
 			preview_lines = {}
 			local picker_lines = {}
 			for _, f in ipairs(results) do
-				table.insert(picker_files, dir .. "/" .. f.file)
-				local fline = string.format("%s:%s %s", f.file:sub(3, -11), f.lnum, f.line)
-				table.insert(picker_lines, fline)
-				table.insert(preview_lines, tonumber(f.lnum))
+				if f.line:len() > 0 then
+					table.insert(picker_files, dir .. "/" .. f.file)
+					local fline = string.format("%s:%s %s", f.file:sub(3, -11), f.lnum, f.line)
+					table.insert(picker_lines, fline)
+					table.insert(preview_lines, tonumber(f.lnum))
+				end
 			end
 
 			vim.api.nvim_buf_set_lines(picker_buf, 0, -1, false, picker_lines)


### PR DESCRIPTION
Hello again :wave:

Your plugin is still amazing, thanks once more for working on it and keeping it open source!

---

This PR adds a new config option: `chat_template`. The default messaging is good, but as i'm familiar with how the plugin works, I don't need to be reminded about the shortcuts each time.

Therefore, i'd like to configure that message, but couldn't find a way to do so. Maybe i missed it?

A bit naive but very simple way is to expose `chat_template` to be configurable. If user decides to set it, then it is up to them to set it correctly.

If `chat_template` is not set, nothing changes and the current message is shown. So no impact for existing users.

Having `chat_template` config option i'm able to:

```lua
require("gp").setup({
  chat_user_prefix = "🗨:",
  chat_template = "# topic: ?\n\n"
    .. "- file: %s\n"
    .. "---\n"
    .. "🗨: "
})
```

and now each chat file looks like:

```markdown
# topic: ?

- file: 2024-03-13.19-09-31.030.md
---
🗨:

```

which is neat, much cleaner!

---

additional thought is that perhaps [markdown frontmatter](https://markdoc.dev/docs/frontmatter
) would fit here for the banner? It is often used to set some extra properties that are not part of markdown body. Lua probably already has some utilities to deal with frontmatter, so chances are it might be easy addition (i'm lua noob, i wouldn't know!).

Anyway, thanks for the plugin, just wanted to share my 2 cents.

Cheers!