### PR TITLE
feat: filter out empty lines from picker window

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2219,10 +2219,12 @@ M.cmd.ChatFinder = function()
 			preview_lines = {}
 			local picker_lines = {}
 			for _, f in ipairs(results) do
-				table.insert(picker_files, dir .. "/" .. f.file)
-				local fline = string.format("%s:%s %s", f.file:sub(3, -11), f.lnum, f.line)
-				table.insert(picker_lines, fline)
-				table.insert(preview_lines, tonumber(f.lnum))
+				if f.line:len() > 0 then
+					table.insert(picker_files, dir .. "/" .. f.file)
+					local fline = string.format("%s:%s %s", f.file:sub(3, -11), f.lnum, f.line)
+					table.insert(picker_lines, fline)
+					table.insert(preview_lines, tonumber(f.lnum))
+				end
 			end
 
 			vim.api.nvim_buf_set_lines(picker_buf, 0, -1, false, picker_lines)


### PR DESCRIPTION
Empty lines as paragraph separators are quite common in ChatGPT's responses. But in most cases we don't want them in the search results. Although they disappear on a simple search of any char, removing them makes the picker window look more compact on startup.


| Before | After |
| - | - |
| ![image](https://github.com/Robitx/gp.nvim/assets/71320000/8006a097-fd0b-499f-8b67-5c85433836a2) | ![image](https://github.com/Robitx/gp.nvim/assets/71320000/35804b94-7737-4e44-bb3a-b4dd92481ee7) |

