### PR TITLE
feat: update defaults to use latest model versions for gpt-4 and gpt-3.5

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -40,7 +40,7 @@ local config = {
 			chat = true,
 			command = false,
 			-- string with model name or table with model name and parameters
-			model = { model = "gpt-4-1106-preview", temperature = 1.1, top_p = 1 },
+			model = { model = "gpt-4o", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
 			system_prompt = "You are a general AI assistant.\n\n"
 				.. "The user provided the additional info about how they would like you to respond:\n\n"
@@ -57,7 +57,7 @@ local config = {
 			chat = true,
 			command = false,
 			-- string with model name or table with model name and parameters
-			model = { model = "gpt-3.5-turbo-1106", temperature = 1.1, top_p = 1 },
+			model = { model = "gpt-3.5-turbo", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
 			system_prompt = "You are a general AI assistant.\n\n"
 				.. "The user provided the additional info about how they would like you to respond:\n\n"
@@ -74,7 +74,7 @@ local config = {
 			chat = false,
 			command = true,
 			-- string with model name or table with model name and parameters
-			model = { model = "gpt-4-1106-preview", temperature = 0.8, top_p = 1 },
+			model = { model = "gpt-4o", temperature = 0.8, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
 			system_prompt = "You are an AI working as a code editor.\n\n"
 				.. "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n"
@@ -85,7 +85,7 @@ local config = {
 			chat = false,
 			command = true,
 			-- string with model name or table with model name and parameters
-			model = { model = "gpt-3.5-turbo-1106", temperature = 0.8, top_p = 1 },
+			model = { model = "gpt-3.5-turbo", temperature = 0.8, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
 			system_prompt = "You are an AI working as a code editor.\n\n"
 				.. "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n"


### PR DESCRIPTION
This pull request introduces updates to the default model configurations in the `config.lua` file to leverage the latest versions of OpenAI's models. Specifically, the `gpt-4o` model has replaced the previous `gpt-4-1106-preview` model, and the `gpt-3.5-turbo` model has replaced the `gpt-3.5-turbo-1106` model. These changes have been applied across various sections of the configuration to ensure consistency and improved performance.

The primary motivation for this update is to take advantage of the enhanced capabilities and optimizations available in the latest model versions. By transitioning to `gpt-4o` and `gpt-3.5-turbo`, users can expect more accurate and efficient AI responses, whether they are engaging in chat-based interactions or utilizing the models for command-based tasks. **The new gpt-4o model is also 50% cheaper.**

In addition to updating the model names, the associated parameters such as temperature and top_p values remain unchanged to retain the existing behavior of the AI. This ensures a smooth transition for users while benefiting from the advancements in the underlying AI technology.