### PR TITLE
feat: add on_complete_callback to gp.Prompt

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1299,7 +1299,7 @@ end
 ---@param handler function # response handler
 ---@param on_exit function | nil # optional on_exit handler
 ---@param on_complete_callback function | nil # optional on_complete_callback handler
-M.query = function(buf, payload, handler, on_exit, on_complete_callback)
+M.query = function(buf, provider, payload, handler, on_exit, on_complete_callback)
 	-- make sure handler is a function
 	if type(handler) ~= "function" then
 		M.error(


### PR DESCRIPTION
I am using the power of gp.nvim to generate a Git commit message after the response is complete.

To do this, I added the `on_complete_callback` argument to the `M.Prompt` and `M.query` functions.

I am a new Neovim user and very new to Lua script. This is my 1st PR.  Feedback is welcome.

Below is an example of how I setup the git commit function.
```lua
hooks = {
    GitCommitStaged = function(gp, params)
      local system_prompt =
        "You are a commit title generator. You use the GPT-4 version of OpenAI's GPT models. You must only provide the commit title. Rules to follows: Write commit title for the change with commitizen convention. Make sure the title has maximum 50 characters. You must not provide additional explination/description other than the git commit title."
      local prompt =
        "Below is the diff of the changes. Please write a commit title for the change. Do not provide any additional information other than the git commit title. Write the commit title."

      local cmd = "git diff --no-color --no-ext-diff --staged"
      local handle = io.popen(cmd)
      if not handle then
        return nil
      end

      local diff = handle:read("*a")
      handle:close()

      if not diff or diff == "" then
        return nil
      end
      local template = prompt .. "\n\n" .. diff

      local agent = gp.get_command_agent()
      gp.info("Generating commit message for staged changes with agent: " .. agent.name)

      local function commit_callback(response)
        vim.notify(response, vim.log.levels.INFO, {
          title = "Git Commit Staged",
          timeout = 5000,
        })
        vim.fn.setreg("+", response)
        vim.notify("Copied commit message to clipboard")
        -- Open up Lazygit and its commit view
        LazyVim.lazygit({ cwd = LazyVim.root.git() })

        -- Wait for 500ms to ensure Lazygit is open
        vim.defer_fn(function()
          -- Run c to open the commit view
          vim.api.nvim_input("c")
          -- Wait another 500ms to ensure the commit view is open
          vim.defer_fn(function()
            -- Use vim.fn.system() to execute a shell command that pastes the commit message
            vim.fn.system('echo -n "' .. vim.fn.getreg("+") .. '" | pbcopy')
            vim.fn.system('osascript -e \'tell application "System Events" to keystroke "v" using command down\'')
          end, 100)
        end, 100)
      end
      gp.Prompt(params, gp.Target.popup, nil, agent.model, template, system_prompt, nil, commit_callback)
    end,
  }
```

Demo:

https://github.com/Robitx/gp.nvim/assets/53516684/9aeebdad-5317-48be-8119-01217fb6971e

