### PR TITLE
Fix spelling of the word bellow to below

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Voice commands (`:GpWhisper*`) depend on `SoX` (Sound eXchange) to handle audio 
 
 ## 5. Configuration
 
-Bellow is a linked snippet with the default values, but I suggest starting with minimal config possible (just `openai_api_key` if you don't have `OPENAI_API_KEY` env set up). Defaults change over time to improve things, options might get deprecated and so on - it's better to change only things where the default doesn't fit your needs.
+Below is a linked snippet with the default values, but I suggest starting with minimal config possible (just `openai_api_key` if you don't have `OPENAI_API_KEY` env set up). Defaults change over time to improve things, options might get deprecated and so on - it's better to change only things where the default doesn't fit your needs.
 
 https://github.com/Robitx/gp.nvim/blob/d90816b2e9185202d72f7b1346b6d33b36350886/lua/gp/config.lua#L8-L355
 
@@ -463,7 +463,7 @@ Ahoy there!
 
 # Shortcuts
 
-There are no default global shortcuts to mess with your own config. Bellow are examples for you to adjust or just use directly.
+There are no default global shortcuts to mess with your own config. Below are examples for you to adjust or just use directly.
 
 ## Native
 
@@ -878,7 +878,7 @@ The raw plugin text editing method `Prompt` has seven aprameters:
 - `template`
 
   - template of the user message send to gpt
-  - string can include variables bellow:
+  - string can include variables below:
 
     | name            | Description                       |
     | --------------- | --------------------------------- |

--- a/doc/gp.nvim.txt
+++ b/doc/gp.nvim.txt
@@ -245,7 +245,7 @@ recording and processing:
 
 5. CONFIGURATION                                    *gp.nvim-5.-configuration*
 
-Bellow is a linked snippet with the default values, but I suggest starting with
+Below is a linked snippet with the default values, but I suggest starting with
 minimal config possible (just `openai_api_key` if you don’t have
 `OPENAI_API_KEY` env set up). Defaults change over time to improve things,
 options might get deprecated and so on - it’s better to change only things
@@ -601,7 +601,7 @@ resulting `test` file:
 ==============================================================================
 4. Shortcuts                                               *gp.nvim-shortcuts*
 
-There are no default global shortcuts to mess with your own config. Bellow are
+There are no default global shortcuts to mess with your own config. Below are
 examples for you to adjust or just use directly.
 
 
@@ -1008,7 +1008,7 @@ The raw plugin text editing method `Prompt` has seven aprameters:
     - see gpt model overview <https://platform.openai.com/docs/models/overview>
 - `template`
     - template of the user message send to gpt
-    - string can include variables bellow:
+    - string can include variables below:
           name            Description
           --------------- -----------------------------------
           {{filetype}}    filetype of the current buffer

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -321,7 +321,7 @@ local config = {
 	style_popup_margin_top = 2,
 	style_popup_max_width = 160,
 
-	-- command config and templates bellow are used by commands like GpRewrite, GpEnew, etc.
+	-- command config and templates below are used by commands like GpRewrite, GpEnew, etc.
 	-- command prompt prefix for asking user for input (supports {{agent}} template variable)
 	command_prompt_prefix_template = "🤖 {{agent}} ~ ",
 	-- auto select command response (easier chaining of commands)

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2881,7 +2881,7 @@ M.cmd.Context = function(params)
 	end
 
 	if vim.fn.filereadable(file_name) ~= 1 then
-		vim.fn.writefile({ "Additional context is provided bellow.", "" }, file_name)
+		vim.fn.writefile({ "Additional context is provided below.", "" }, file_name)
 	end
 
 	params.args = params.args or ""


### PR DESCRIPTION
Found a few places that used bellow instead of below and corrected them.

Thanks for all the work on this plugin!