### PR TITLE
fix(README): Correct configuration lines in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Voice commands (`:GpWhisper*`) depend on `SoX` (Sound eXchange) to handle audio 
 
 Below is a linked snippet with the default values, but I suggest starting with minimal config possible (just `openai_api_key` if you don't have `OPENAI_API_KEY` env set up). Defaults change over time to improve things, options might get deprecated and so on - it's better to change only things where the default doesn't fit your needs.
 
-https://github.com/Robitx/gp.nvim/blob/d90816b2e9185202d72f7b1346b6d33b36350886/lua/gp/config.lua#L8-L355
+https://github.com/Robitx/gp.nvim/blob/main/lua/gp/config.lua#L23-L569
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Voice commands (`:GpWhisper*`) depend on `SoX` (Sound eXchange) to handle audio 
 
 Below is a linked snippet with the default values, but I suggest starting with minimal config possible (just `openai_api_key` if you don't have `OPENAI_API_KEY` env set up). Defaults change over time to improve things, options might get deprecated and so on - it's better to change only things where the default doesn't fit your needs.
 
-https://github.com/Robitx/gp.nvim/blob/main/lua/gp/config.lua#L23-L569
+https://github.com/Robitx/gp.nvim/blob/2169a731aec0108ad545b68bd95ef705e6c0e27b/lua/gp/config.lua#L23-L569
 
 # Usage
 

--- a/doc/gp.nvim.txt
+++ b/doc/gp.nvim.txt
@@ -1,4 +1,4 @@
-*gp.nvim.txt*             For NVIM v0.8.0            Last change: 2024 July 15
+*gp.nvim.txt*             For NVIM v0.8.0            Last change: 2024 July 16
 
 ==============================================================================
 Table of Contents                                  *gp.nvim-table-of-contents*
@@ -252,7 +252,7 @@ options might get deprecated and so on - it’s better to change only things
 where the default doesn’t fit your needs.
 
 
-https://github.com/Robitx/gp.nvim/blob/d90816b2e9185202d72f7b1346b6d33b36350886/lua/gp/config.lua#L8-L355
+https://github.com/Robitx/gp.nvim/blob/2169a731aec0108ad545b68bd95ef705e6c0e27b/lua/gp/config.lua#L23-L569
 
 
 ==============================================================================

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -19,6 +19,7 @@ local default_code_system_prompt = "You are an AI working as a code editor.\n\n"
 	.. "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n"
 	.. "START AND END YOUR ANSWER WITH:\n\n```"
 
+-- ATTENTION: When you update `config`, you should update the line numbers in the README in the section ##Configuration!
 local config = {
 	-- Please start with minimal config possible.
 	-- Just openai_api_key if you don't have OPENAI_API_KEY env set up.


### PR DESCRIPTION
- Use the main and HEAD for the snippet in README for the configuration.
- Added a note for developer, that if the configuration changes, he/she
  should update the README link line numbers

Reason: It can be quite counterintuitive to setup the configuration that
is not up to date such that something from the copied configuration is
already deprecated. It should also adhere to the new `provider` format,
so that users know what to use.
