### PR TITLE
feat: expose default_(chat|code)_system_prompt to user

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -5,20 +5,6 @@
 -- Default config
 --------------------------------------------------------------------------------
 
-local default_chat_system_prompt = "You are a general AI assistant.\n\n"
-	.. "The user provided the additional info about how they would like you to respond:\n\n"
-	.. "- If you're unsure don't guess and say you don't know instead.\n"
-	.. "- Ask question if you need clarification to provide better answer.\n"
-	.. "- Think deeply and carefully from first principles step by step.\n"
-	.. "- Zoom out first to see the big picture and then zoom in to details.\n"
-	.. "- Use Socratic method to improve your thinking and coding skills.\n"
-	.. "- Don't elide any code from your output if the answer requires coding.\n"
-	.. "- Take a deep breath; You've got this!\n"
-
-local default_code_system_prompt = "You are an AI working as a code editor.\n\n"
-	.. "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n"
-	.. "START AND END YOUR ANSWER WITH:\n\n```"
-
 local config = {
 	-- Please start with minimal config possible.
 	-- Just openai_api_key if you don't have OPENAI_API_KEY env set up.
@@ -110,7 +96,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "gpt-4o", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_chat_system_prompt,
+			system_prompt = require'gp.defaults'.chat_system_prompt,
 		},
 		{
 			provider = "openai",
@@ -120,7 +106,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "gpt-3.5-turbo", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_chat_system_prompt,
+			system_prompt = require'gp.defaults'.chat_system_prompt,
 		},
 		{
 			provider = "copilot",
@@ -130,7 +116,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "gpt-4", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_chat_system_prompt,
+			system_prompt = require'gp.defaults'.chat_system_prompt,
 		},
 		{
 			provider = "googleai",
@@ -140,7 +126,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "gemini-pro", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_chat_system_prompt,
+			system_prompt = require'gp.defaults'.chat_system_prompt,
 		},
 		{
 			provider = "pplx",
@@ -150,7 +136,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "mixtral-8x7b-instruct", temperature = 1.1, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_chat_system_prompt,
+			system_prompt = require'gp.defaults'.chat_system_prompt,
 		},
 		{
 			provider = "anthropic",
@@ -160,7 +146,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "claude-3-5-sonnet-20240620", temperature = 0.8, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_chat_system_prompt,
+			system_prompt = require'gp.defaults'.chat_system_prompt,
 		},
 		{
 			provider = "anthropic",
@@ -170,7 +156,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "claude-3-haiku-20240307", temperature = 0.8, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_chat_system_prompt,
+			system_prompt = require'gp.defaults'.chat_system_prompt,
 		},
 		{
 			provider = "ollama",
@@ -208,7 +194,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "gpt-4o", temperature = 0.8, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_code_system_prompt,
+			system_prompt = require'gp.defaults'.code_system_prompt,
 		},
 		{
 			provider = "openai",
@@ -218,7 +204,7 @@ local config = {
 			-- string with model name or table with model name and parameters
 			model = { model = "gpt-3.5-turbo", temperature = 0.8, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_code_system_prompt,
+			system_prompt = require'gp.defaults'.code_system_prompt,
 		},
 		{
 			provider = "copilot",
@@ -228,7 +214,7 @@ local config = {
 			-- string with the Copilot engine name or table with engine name and parameters if applicable
 			model = { model = "gpt-4", temperature = 0.8, top_p = 1, n = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
-			system_prompt = default_code_system_prompt,
+			system_prompt = require'gp.defaults'.code_system_prompt,
 		},
 		{
 			provider = "googleai",
@@ -237,7 +223,7 @@ local config = {
 			command = true,
 			-- string with model name or table with model name and parameters
 			model = { model = "gemini-pro", temperature = 0.8, top_p = 1 },
-			system_prompt = default_code_system_prompt,
+			system_prompt = require'gp.defaults'.code_system_prompt,
 		},
 		{
 			provider = "pplx",
@@ -246,7 +232,7 @@ local config = {
 			command = true,
 			-- string with model name or table with model name and parameters
 			model = { model = "mixtral-8x7b-instruct", temperature = 0.8, top_p = 1 },
-			system_prompt = default_code_system_prompt,
+			system_prompt = require'gp.defaults'.code_system_prompt,
 		},
 		{
 			provider = "anthropic",
@@ -255,7 +241,7 @@ local config = {
 			command = true,
 			-- string with model name or table with model name and parameters
 			model = { model = "claude-3-5-sonnet-20240620", temperature = 0.8, top_p = 1 },
-			system_prompt = default_code_system_prompt,
+			system_prompt = require'gp.defaults'.code_system_prompt,
 		},
 		{
 			provider = "anthropic",
@@ -264,7 +250,7 @@ local config = {
 			command = true,
 			-- string with model name or table with model name and parameters
 			model = { model = "claude-3-haiku-20240307", temperature = 0.8, top_p = 1 },
-			system_prompt = default_code_system_prompt,
+			system_prompt = require'gp.defaults'.code_system_prompt,
 		},
 		{
 			provider = "ollama",

--- a/lua/gp/defaults.lua
+++ b/lua/gp/defaults.lua
@@ -1,0 +1,16 @@
+local M = {}
+M.chat_system_prompt = "You are a general AI assistant.\n\n"
+	.. "The user provided the additional info about how they would like you to respond:\n\n"
+	.. "- If you're unsure don't guess and say you don't know instead.\n"
+	.. "- Ask question if you need clarification to provide better answer.\n"
+	.. "- Think deeply and carefully from first principles step by step.\n"
+	.. "- Zoom out first to see the big picture and then zoom in to details.\n"
+	.. "- Use Socratic method to improve your thinking and coding skills.\n"
+	.. "- Don't elide any code from your output if the answer requires coding.\n"
+	.. "- Take a deep breath; You've got this!\n"
+
+M.code_system_prompt = "You are an AI working as a code editor.\n\n"
+	.. "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n"
+	.. "START AND END YOUR ANSWER WITH:\n\n```"
+
+return M


### PR DESCRIPTION
When adding your own agents, you have to provide default prompts. Let's expose gp.nvim's default ones t avoid the user troubling him/herself with the issue.

the "default" in names might be redundant. 