### PR TITLE
feat: added headers for openrouter

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1418,7 +1418,7 @@ M.query = function(buf, provider, payload, handler, on_exit, callback)
 
 					process_lines(complete_lines)
 				end
-			-- chunk is nil when EOF is reached
+				-- chunk is nil when EOF is reached
 			else
 				-- if there's remaining data in the buffer, process it
 				if #buffer > 0 then
@@ -1473,6 +1473,13 @@ M.query = function(buf, provider, payload, handler, on_exit, callback)
 			-- backwards compatibility
 			"-H",
 			"api-key: " .. bearer,
+		}
+	end
+
+	if provider == "openrouter" then
+		headers = {
+			"-H",
+			"Authorization: Bearer " .. bearer,
 		}
 	end
 


### PR DESCRIPTION
Hello. Thanks for the great plugin. Pretty minor change, but this allows the use of openrouter without requiring somebody to specify their openai provider should be openrouter and complicating access to the other aspects of openai's ecosystem. If I need to edit it to flesh out openrouter support as an option, I can. But really it just needs the header defined. Also happy to consider other options.