### PR TITLE
Fixes bug deleting chat file when config.chat_dir contains a symlink

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2184,7 +2184,7 @@ M.cmd.ChatDelete = function()
 	local file_name = vim.api.nvim_buf_get_name(buf)
 
 	-- check if file is in the chat dir
-	if not _H.starts_with(file_name, M.config.chat_dir) then
+	if not _H.starts_with(file_name, vim.fn.resolve(M.config.chat_dir)) then
 		M.logger.warning("File " .. vim.inspect(file_name) .. " is not in chat dir")
 		return
 	end


### PR DESCRIPTION
# The Bug
When deleting a chat, if any path component in `config.chat_dir` is a symlink, the following sanity check fails:

```lua
	if not _H.starts_with(file_name, M.config.chat_dir) then
		M.logger.warning("File " .. vim.inspect(file_name) .. " is not in chat dir")
		return
	end
```

This causes the GpChatDelete command to always fail in such cases.

# The fix
Resolve `chat_dir` symlinks when performing the sanity check.