### PR TITLE
Capture the preceding parameters for ChatRespond

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -2429,9 +2429,11 @@ M.chat_respond = function(params)
 end
 
 M.cmd.ChatRespond = function(params)
-	if params.args == "" then
+	if params.args == "" and vim.v.count == 0 then
 		M.chat_respond(params)
 		return
+	elseif params.args == "" and vim.v.count ~= 0 then
+		params.args = tostring(vim.v.count)
 	end
 
 	-- ensure args is a single positive number

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1786,7 +1786,9 @@ M.prep_chat = function(buf, file_name)
 
 	-- make last.md a symlink to the last opened chat file
 	local last = M.config.chat_dir .. "/last.md"
-	if file_name ~= last then
+	if file_name ~= last and vim.fn.has("win32") then
+		os.execute("pwsh -c New-Item -Force -ItemType SymbolicLink -Path " .. last .. " -Target " .. file_name)
+	elseif file_name ~= last then
 		os.execute("ln -sf " .. file_name .. " " .. last)
 	end
 end


### PR DESCRIPTION
I hope to be able to obtain input parameters before using the command.，This can better coordinate with the use of keymap.
For example, when I input `1<c-g><c-g>`, it can send a question in a new chat.