### PR TITLE
add max_tokens to payload

### DIFF
--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -169,6 +169,7 @@ D.prepare_payload = function(messages, model, provider)
 		model = model.model,
 		stream = true,
 		messages = messages,
+		max_tokens = model.max_tokens or 4096,
 		temperature = math.max(0, math.min(2, model.temperature or 1)),
 		top_p = math.max(0, math.min(1, model.top_p or 1)),
 	}


### PR DESCRIPTION
For OpenAI-compatible endpoints, the plugin doesn't pass the max_tokens parameter. 