### PR TITLE
feat: ':GpAgent' should print the current agents

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1489,7 +1489,7 @@ end
 M.cmd.Agent = function(params)
 	local agent_name = string.gsub(params.args, "^%s*(.-)%s*$", "%1")
 	if agent_name == "" then
-		M.logger.info(" Chat agent: " .. M._state.chat_agent .. "  |  Command agent: " .. M._state.command_agent)
+		print(" Chat agent: " .. M._state.chat_agent .. "  |  Command agent: " .. M._state.command_agent)
 		return
 	end
 


### PR DESCRIPTION
It used to be the case but got lost during the logger addition. It now gets forwarded to the log but it's more useful in message area