### PR TITLE
feat: add Makefile to be able to regen the doc locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+doc: README.md
+	panvimdoc --project-name gp.nvim --vim-version "neovim" --input-file README.md --demojify true --treesitter true --doc-mapping true --doc-mapping-project-name true --dedup-subheadings true 


### PR DESCRIPTION
the user still has to install the deps (e.g. `nix shell nixpkgs#panvimdoc` with nix) but then can run `make doc`.

It duplicates the info in .github/workflows/docgen.yml  (which is why I usually have the CI call the project scripts instead, makes reproducing CI easier). In this case it's small so should be fine.

Feel free to close. I just like to test commands locally rather than waiting for CI.