### PR TITLE
feat: handle o1 when used with copilot provider

### DIFF
--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -174,7 +174,7 @@ D.prepare_payload = function(messages, model, provider)
 		top_p = math.max(0, math.min(1, model.top_p or 1)),
 	}
 
-	if provider == "openai" and model.model:sub(1, 2) == "o1" then
+	if (provider == "openai" or provider == "copilot") and model.model:sub(1, 2) == "o1" then
 		for i = #messages, 1, -1 do
 			if messages[i].role == "system" then
 				table.remove(messages, i)
@@ -300,7 +300,7 @@ local query = function(buf, provider, payload, handler, on_exit, callback)
 				end
 				local raw_response = qt.raw_response
 				local content = qt.response
-				if qt.provider == 'openai' and content == "" and raw_response:match('choices') and raw_response:match("content") then
+				if (qt.provider == 'openai' or qt.provider == 'copilot') and content == "" and raw_response:match('choices') and raw_response:match("content") then
 					local response = vim.json.decode(raw_response)
 					if response.choices and response.choices[1] and response.choices[1].message and response.choices[1].message.content then
 						content = response.choices[1].message.content


### PR DESCRIPTION
The o1-preview and o1-mini models can be used with copilot provider when you have a copilot pro subscription. This ensures the request/response are handled in those cases (currently only openai provider is handled).