### PR TITLE
Allow commands to be input from a floating window

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -355,6 +355,8 @@ local config = {
 	-- auto select command response (easier chaining of commands)
 	-- if false it also frees up the buffer cursor for further editing elsewhere
 	command_auto_select_response = true,
+	-- if enabled, will use a floating window + scratch buffer for reading user command
+	command_floating_window = false,
 
 	-- templates
 	template_selection = "I have the following from {{filename}}:"

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1485,7 +1485,6 @@ end
 --------------------------------------------------------------------------------
 -- Prompt logic
 --------------------------------------------------------------------------------
-
 M.cmd.Agent = function(params)
 	local agent_name = string.gsub(params.args, "^%s*(.-)%s*$", "%1")
 	if agent_name == "" then
@@ -1952,13 +1951,24 @@ M.Prompt = function(params, target, agent, template, prompt, whisper, callback)
 			return
 		end
 
-		-- if prompt is provided, ask the user to enter the command
-		vim.ui.input({ prompt = prompt, default = whisper }, function(input)
+		local function input_callback(input)
 			if not input or input == "" then
 				return
 			end
 			cb(input)
-		end)
+		end
+
+		-- if prompt is provided, ask the user to enter the command
+		if M.config.command_floating_window then
+			M.helpers.floating_input({
+				prompt = prompt,
+				default = whisper,
+				accept_shortcut = M.config.chat_shortcut_respond.shortcut,
+				accept_modes = M.config.chat_shortcut_respond.modes
+			}, input_callback)
+		else
+			vim.ui.input({ prompt = prompt, default = whisper }, input_callback)
+		end
 	end)
 end
 


### PR DESCRIPTION
This adds a new `command_floating_window` option. When set to true, gp will use a floating window + scratch buffer to read the command. The map to accept the input is the same as the one to send a message in the chat window (ctrl+g, ctrl+g by default).