### PR TITLE
add o3 support

### DIFF
--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -174,7 +174,11 @@ D.prepare_payload = function(messages, model, provider)
 		top_p = math.max(0, math.min(1, model.top_p or 1)),
 	}
 
-	if provider == "openai" and model.model:sub(1, 2) == "o1" then
+	if provider == "openai" and model.model:sub(1, 1) == "o" then
+		if model.model:sub(1, 2) == "o3" then
+			output.reasoning_effort = model.reasoning_effort or "medium"
+		end
+
 		for i = #messages, 1, -1 do
 			if messages[i].role == "system" then
 				table.remove(messages, i)
@@ -184,7 +188,6 @@ D.prepare_payload = function(messages, model, provider)
 		output.max_tokens = nil
 		output.temperature = nil
 		output.top_p = nil
-		output.stream = false
 	end
 
 	return output


### PR DESCRIPTION
o series of models supports streaming now
add support for o3 reasoning model
use [`reasoning_effort`](https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort) property from model on o3 series of models (defaults to "medium", other options being "low" and "high")

Closes [245](https://github.com/Robitx/gp.nvim/issues/245)