### PR TITLE
Add OpenAI Models: 4.1, 4.1 Mini, and 4.1 Nano

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -132,6 +132,36 @@ local config = {
 			system_prompt = require("gp.defaults").chat_system_prompt,
 		},
 		{
+			provider = "openai",
+			name = "ChatGPT4-1",
+			chat = true,
+			command = false,
+			-- string with model name or table with model name and parameters
+			model = { model = "gpt-4.1", temperature = 1.1, top_p = 1 },
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = require("gp.defaults").chat_system_prompt,
+		},
+		{
+			provider = "openai",
+			name = "ChatGPT4-1-mini",
+			chat = true,
+			command = false,
+			-- string with model name or table with model name and parameters
+			model = { model = "gpt-4.1-mini", temperature = 1.1, top_p = 1 },
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = require("gp.defaults").chat_system_prompt,
+		},
+		{
+			provider = "openai",
+			name = "ChatGPT4-1-nano",
+			chat = true,
+			command = false,
+			-- string with model name or table with model name and parameters
+			model = { model = "gpt-4.1-nano", temperature = 1.1, top_p = 1 },
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = require("gp.defaults").chat_system_prompt,
+		},
+		{
 			provider = "copilot",
 			name = "ChatCopilot",
 			chat = true,
@@ -240,6 +270,36 @@ local config = {
 			model = { model = "gpt-4o-mini", temperature = 0.7, top_p = 1 },
 			-- system prompt (use this to specify the persona/role of the AI)
 			system_prompt = "Please return ONLY code snippets.\nSTART AND END YOUR ANSWER WITH:\n\n```",
+		},
+		{
+			provider = "openai",
+			name = "CodeGPT4-1",
+			chat = false,
+			command = true,
+			-- string with model name or table with model name and parameters
+			model = { model = "gpt-4.1", temperature = 0.8, top_p = 1 },
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = require("gp.defaults").code_system_prompt,
+		},
+		{
+			provider = "openai",
+			name = "CodeGPT4-1-mini",
+			chat = false,
+			command = true,
+			-- string with model name or table with model name and parameters
+			model = { model = "gpt-4.1-mini", temperature = 0.7, top_p = 1 },
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = require("gp.defaults").code_system_prompt,
+		},
+		{
+			provider = "openai",
+			name = "CodeGPT4-1-nano",
+			chat = false,
+			command = true,
+			-- string with model name or table with model name and parameters
+			model = { model = "gpt-4.1-nano", temperature = 0.6, top_p = 1 },
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = require("gp.defaults").code_system_prompt,
 		},
 		{
 			provider = "copilot",


### PR DESCRIPTION
### Summary
This pull request adds support for the new OpenAI models: 4.1, 4.1 Mini, and 4.1 Nano.

### Changes Made
- Added model definitions for OpenAI 4.1, 4.1 Mini, and 4.1 Nano in the CodeGPT and ChatGPT agents.
- Ensured compatibility with existing code and functionality.
