### PR TITLE
fix: update sed regex for extracting copilot oauth in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Below is an example of the relevant configuration part enabling some of these. T
 			secret = {
 				"bash",
 				"-c",
-				"cat ~/.config/github-copilot/hosts.json | sed -n 's/.*"oauth_token":"\([^"]*\)".*/\1/p'",
+				"cat ~/.config/github-copilot/apps.json | sed -n 's/.*"oauth_token":"\([^"]*\)".*/\1/p'",
 			},
 		},
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Below is an example of the relevant configuration part enabling some of these. T
 			secret = {
 				"bash",
 				"-c",
-				"cat ~/.config/github-copilot/hosts.json | sed -e 's/.*oauth_token...//;s/\".*//'",
+				"cat ~/.config/github-copilot/hosts.json | sed -n 's/.*"oauth_token":"\([^"]*\)".*/\1/p'",
 			},
 		},
 


### PR DESCRIPTION
Previous example was cut of and didn't render properly in the markdown.