### PR TITLE
fix: setting content type of mp3 file in whisper transcribe

### DIFF
--- a/lua/gp/whisper.lua
+++ b/lua/gp/whisper.lua
@@ -205,7 +205,7 @@ local whisper = function(callback, language)
 			.. '" -H "Content-Type: multipart/form-data" '
 			.. '-F model="whisper-1" -F language="'
 			.. language
-			.. '" -F file="@final.mp3" '
+			.. '" -F file="@final.mp3;type=audio/mpeg" '
 			.. '-F response_format="json"'
 
 		tasker.run(nil, "bash", { "-c", cmd }, function(code, signal, stdout, _)


### PR DESCRIPTION
When whisper sends the transcribe request the content-type was missing from the file parameter.
That caused some transcription endpoints to not correctly recognize the content type audio/mpeg. 