### PR TITLE
feat: add :GpSelectAgent to improve selection of agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ Displays currently used agents for chat and command instructions.
 
 Choose a new agent based on its name, listing options based on the current buffer (chat agents if current buffer is a chat and command agents otherwise). The agent setting is persisted on disk across Neovim instances.
 
+#### `:GpAgentSelect` <!-- {doc=:GPAgentSelect}  -->
+
+Opens a selection interface using `vim.ui.select` to choose from all available agents, allowing you to directly select the desired agent from a list. Works seamlessly with telescope if available.
+
 ## Image commands
 
 #### `:GpImage` <!-- {doc=:GpImage}  -->

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Displays currently used agents for chat and command instructions.
 
 Choose a new agent based on its name, listing options based on the current buffer (chat agents if current buffer is a chat and command agents otherwise). The agent setting is persisted on disk across Neovim instances.
 
-#### `:GpSelectAgent` <!-- {doc=:GPSelectAgent}  -->
+#### `:GpSelectAgent` <!-- {doc=:GpSelectAgent}  -->
 
 Opens a selection interface using `vim.ui.select` to choose from all available agents, allowing you to directly select the desired agent from a list. Works seamlessly with telescope if available.
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Displays currently used agents for chat and command instructions.
 
 Choose a new agent based on its name, listing options based on the current buffer (chat agents if current buffer is a chat and command agents otherwise). The agent setting is persisted on disk across Neovim instances.
 
-#### `:GpAgentSelect` <!-- {doc=:GPAgentSelect}  -->
+#### `:GpSelectAgent` <!-- {doc=:GPSelectAgent}  -->
 
 Opens a selection interface using `vim.ui.select` to choose from all available agents, allowing you to directly select the desired agent from a list. Works seamlessly with telescope if available.
 
@@ -534,6 +534,7 @@ vim.keymap.set("v", "<C-g>x", ":<C-u>'<,'>GpContext<cr>", keymapOptions("Visual 
 
 vim.keymap.set({"n", "i", "v", "x"}, "<C-g>s", "<cmd>GpStop<cr>", keymapOptions("Stop"))
 vim.keymap.set({"n", "i", "v", "x"}, "<C-g>n", "<cmd>GpNextAgent<cr>", keymapOptions("Next Agent"))
+vim.keymap.set({"n", "i", "v", "x"}, "<C-g>j", "<cmd>GpSelectAgent<cr>", keymapOptions("Select Agent"))
 
 -- optional Whisper commands with prefix <C-g>w
 vim.keymap.set({"n", "i"}, "<C-g>ww", "<cmd>GpWhisper<cr>", keymapOptions("Whisper"))
@@ -586,6 +587,7 @@ require("which-key").add({
         { "<C-g>gv", ":<C-u>'<,'>GpVnew<cr>", desc = "Visual GpVnew" },
         { "<C-g>i", ":<C-u>'<,'>GpImplement<cr>", desc = "Implement selection" },
         { "<C-g>n", "<cmd>GpNextAgent<cr>", desc = "Next Agent" },
+        { "<C-g>j", "<cmd>GpSelectAgent<cr>", desc = "Select Agent" },
         { "<C-g>p", ":<C-u>'<,'>GpChatPaste<cr>", desc = "Visual Chat Paste" },
         { "<C-g>r", ":<C-u>'<,'>GpRewrite<cr>", desc = "Visual Rewrite" },
         { "<C-g>s", "<cmd>GpStop<cr>", desc = "GpStop" },
@@ -622,6 +624,7 @@ require("which-key").add({
         { "<C-g>gt", "<cmd>GpTabnew<cr>", desc = "GpTabnew" },
         { "<C-g>gv", "<cmd>GpVnew<cr>", desc = "GpVnew" },
         { "<C-g>n", "<cmd>GpNextAgent<cr>", desc = "Next Agent" },
+        { "<C-g>j", "<cmd>GpSelectAgent<cr>", desc = "Select Agent" },
         { "<C-g>r", "<cmd>GpRewrite<cr>", desc = "Inline Rewrite" },
         { "<C-g>s", "<cmd>GpStop<cr>", desc = "GpStop" },
         { "<C-g>t", "<cmd>GpChatToggle<cr>", desc = "Toggle Chat" },
@@ -657,6 +660,7 @@ require("which-key").add({
         { "<C-g>gt", "<cmd>GpTabnew<cr>", desc = "GpTabnew" },
         { "<C-g>gv", "<cmd>GpVnew<cr>", desc = "GpVnew" },
         { "<C-g>n", "<cmd>GpNextAgent<cr>", desc = "Next Agent" },
+        { "<C-g>j", "<cmd>GpSelectAgent<cr>", desc = "Select Agent" },
         { "<C-g>r", "<cmd>GpRewrite<cr>", desc = "Inline Rewrite" },
         { "<C-g>s", "<cmd>GpStop<cr>", desc = "GpStop" },
         { "<C-g>t", "<cmd>GpChatToggle<cr>", desc = "Toggle Chat" },

--- a/doc/gp.nvim.txt
+++ b/doc/gp.nvim.txt
@@ -482,6 +482,12 @@ Choose a new agent based on its name, listing options based on the current
 buffer (chat agents if current buffer is a chat and command agents otherwise).
 The agent setting is persisted on disk across Neovim instances.
 
+:GpAgentSelect                                                *:GpAgentSelect*
+
+Opens a selection interface using `vim.ui.select` to choose from all available
+agents, allowing you to directly select the desired agent from a list. Works
+seamlessly with telescope if available.
+
 
 IMAGE COMMANDS                                        *gp.nvim-image-commands*
 

--- a/doc/gp.nvim.txt
+++ b/doc/gp.nvim.txt
@@ -482,7 +482,8 @@ Choose a new agent based on its name, listing options based on the current
 buffer (chat agents if current buffer is a chat and command agents otherwise).
 The agent setting is persisted on disk across Neovim instances.
 
-:GpAgentSelect                                                *:GpAgentSelect*
+
+:GpSelectAgent                                                *:GpSelectAgent*
 
 Opens a selection interface using `vim.ui.select` to choose from all available
 agents, allowing you to directly select the desired agent from a list. Works
@@ -674,6 +675,7 @@ them at one place).
     
     vim.keymap.set({"n", "i", "v", "x"}, "<C-g>s", "<cmd>GpStop<cr>", keymapOptions("Stop"))
     vim.keymap.set({"n", "i", "v", "x"}, "<C-g>n", "<cmd>GpNextAgent<cr>", keymapOptions("Next Agent"))
+    vim.keymap.set({"n", "i", "v", "x"}, "<C-g>j", "<cmd>GpSelectAgent<cr>", keymapOptions("Select Agent"))
     
     -- optional Whisper commands with prefix <C-g>w
     vim.keymap.set({"n", "i"}, "<C-g>ww", "<cmd>GpWhisper<cr>", keymapOptions("Whisper"))
@@ -728,6 +730,7 @@ Or go more fancy by using which-key.nvim
             { "<C-g>gv", ":<C-u>'<,'>GpVnew<cr>", desc = "Visual GpVnew" },
             { "<C-g>i", ":<C-u>'<,'>GpImplement<cr>", desc = "Implement selection" },
             { "<C-g>n", "<cmd>GpNextAgent<cr>", desc = "Next Agent" },
+            { "<C-g>j", "<cmd>GpSelectAgent<cr>", desc = "Select Agent" },
             { "<C-g>p", ":<C-u>'<,'>GpChatPaste<cr>", desc = "Visual Chat Paste" },
             { "<C-g>r", ":<C-u>'<,'>GpRewrite<cr>", desc = "Visual Rewrite" },
             { "<C-g>s", "<cmd>GpStop<cr>", desc = "GpStop" },
@@ -764,6 +767,7 @@ Or go more fancy by using which-key.nvim
             { "<C-g>gt", "<cmd>GpTabnew<cr>", desc = "GpTabnew" },
             { "<C-g>gv", "<cmd>GpVnew<cr>", desc = "GpVnew" },
             { "<C-g>n", "<cmd>GpNextAgent<cr>", desc = "Next Agent" },
+            { "<C-g>j", "<cmd>GpSelectAgent<cr>", desc = "Select Agent" },
             { "<C-g>r", "<cmd>GpRewrite<cr>", desc = "Inline Rewrite" },
             { "<C-g>s", "<cmd>GpStop<cr>", desc = "GpStop" },
             { "<C-g>t", "<cmd>GpChatToggle<cr>", desc = "Toggle Chat" },
@@ -799,6 +803,7 @@ Or go more fancy by using which-key.nvim
             { "<C-g>gt", "<cmd>GpTabnew<cr>", desc = "GpTabnew" },
             { "<C-g>gv", "<cmd>GpVnew<cr>", desc = "GpVnew" },
             { "<C-g>n", "<cmd>GpNextAgent<cr>", desc = "Next Agent" },
+            { "<C-g>j", "<cmd>GpSelectAgent<cr>", desc = "Select Agent" },
             { "<C-g>r", "<cmd>GpRewrite<cr>", desc = "Inline Rewrite" },
             { "<C-g>s", "<cmd>GpStop<cr>", desc = "GpStop" },
             { "<C-g>t", "<cmd>GpChatToggle<cr>", desc = "Toggle Chat" },

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -7,23 +7,23 @@
 local config = require("gp.config")
 
 local M = {
-	_Name = "Gp", -- plugin name
-	_state = {}, -- table of state variables
-	agents = {}, -- table of agents
-	cmd = {}, -- default command functions
-	config = {}, -- config variables
-	hooks = {}, -- user defined command functions
-	defaults = require("gp.defaults"), -- some useful defaults
+	_Name = "Gp",                          -- plugin name
+	_state = {},                           -- table of state variables
+	agents = {},                           -- table of agents
+	cmd = {},                              -- default command functions
+	config = {},                           -- config variables
+	hooks = {},                            -- user defined command functions
+	defaults = require("gp.defaults"),     -- some useful defaults
 	deprecator = require("gp.deprecator"), -- handle deprecated options
 	dispatcher = require("gp.dispatcher"), -- handle communication with LLM providers
-	helpers = require("gp.helper"), -- helper functions
-	imager = require("gp.imager"), -- image generation module
-	logger = require("gp.logger"), -- logger module
-	render = require("gp.render"), -- render module
-	spinner = require("gp.spinner"), -- spinner module
-	tasker = require("gp.tasker"), -- tasker module
-	vault = require("gp.vault"), -- handles secrets
-	whisper = require("gp.whisper"), -- whisper module
+	helpers = require("gp.helper"),        -- helper functions
+	imager = require("gp.imager"),         -- image generation module
+	logger = require("gp.logger"),         -- logger module
+	render = require("gp.render"),         -- render module
+	spinner = require("gp.spinner"),       -- spinner module
+	tasker = require("gp.tasker"),         -- tasker module
+	vault = require("gp.vault"),           -- handles secrets
+	whisper = require("gp.whisper"),       -- whisper module
 }
 
 --------------------------------------------------------------------------------
@@ -137,11 +137,11 @@ M.setup = function(opts)
 		elseif not agent.model or not agent.system_prompt then
 			M.logger.warning(
 				"Agent "
-					.. name
-					.. " is missing model or system_prompt\n"
-					.. "If you want to disable an agent, use: { name = '"
-					.. name
-					.. "', disable = true },"
+				.. name
+				.. " is missing model or system_prompt\n"
+				.. "If you want to disable an agent, use: { name = '"
+				.. name
+				.. "', disable = true },"
 			)
 			M.agents[name] = nil
 		end
@@ -282,9 +282,9 @@ end
 
 M.Target = {
 	rewrite = 0, -- for replacing the selection, range or the current line
-	append = 1, -- for appending after the selection, range or the current line
+	append = 1,  -- for appending after the selection, range or the current line
 	prepend = 2, -- for prepending before the selection, range or the current line
-	popup = 3, -- for writing into the popup window
+	popup = 3,   -- for writing into the popup window
 
 	-- for writing into a new buffer
 	---@param filetype nil | string # nil = same as the original buffer
@@ -378,8 +378,8 @@ M._toggle = {}
 
 M._toggle_kind = {
 	unknown = 0, -- unknown toggle
-	chat = 1, -- chat toggle
-	popup = 2, -- popup toggle
+	chat = 1,    -- chat toggle
+	popup = 2,   -- popup toggle
 	context = 3, -- context toggle
 }
 
@@ -387,13 +387,13 @@ M._toggle_kind = {
 ---@return boolean # true if toggle was closed
 M._toggle_close = function(kind)
 	if
-		M._toggle[kind]
-		and M._toggle[kind].win
-		and M._toggle[kind].buf
-		and M._toggle[kind].close
-		and vim.api.nvim_win_is_valid(M._toggle[kind].win)
-		and vim.api.nvim_buf_is_valid(M._toggle[kind].buf)
-		and vim.api.nvim_win_get_buf(M._toggle[kind].win) == M._toggle[kind].buf
+					M._toggle[kind]
+					and M._toggle[kind].win
+					and M._toggle[kind].buf
+					and M._toggle[kind].close
+					and vim.api.nvim_win_is_valid(M._toggle[kind].win)
+					and vim.api.nvim_buf_is_valid(M._toggle[kind].buf)
+					and vim.api.nvim_win_get_buf(M._toggle[kind].win) == M._toggle[kind].buf
 	then
 		if #vim.api.nvim_list_wins() == 1 then
 			M.logger.warning("Can't close the last window.")
@@ -609,10 +609,10 @@ end
 
 M.BufTarget = {
 	current = 0, -- current window
-	popup = 1, -- popup window
-	split = 2, -- split window
-	vsplit = 3, -- vsplit window
-	tabnew = 4, -- new tab
+	popup = 1,   -- popup window
+	split = 2,   -- split window
+	vsplit = 3,  -- vsplit window
+	tabnew = 4,  -- new tab
 }
 
 ---@param params table | string # table with args or string args
@@ -1233,7 +1233,7 @@ M.cmd.ChatFinder = function()
 	local command_buf, command_win, command_close, command_resize = M.render.popup(
 		nil,
 		"Search: <Tab>/<Shift+Tab>|navigate <Esc>|picker <C-c>|exit "
-			.. "<Enter>/<C-f>/<C-x>/<C-v>/<C-t>/<C-g>t|open/float/split/vsplit/tab/toggle",
+		.. "<Enter>/<C-f>/<C-x>/<C-v>/<C-t>/<C-g>t|open/float/split/vsplit/tab/toggle",
 		function(w, h)
 			return w - left - right, 1, h - bottom, left
 		end,
@@ -1546,7 +1546,7 @@ M.cmd.NextAgent = function()
 	set_agent(agent_list[1])
 end
 
-M.cmd.AgentSelect = function()
+M.cmd.SelectAgent = function()
 	local buf = vim.api.nvim_get_current_buf()
 	local file_name = vim.api.nvim_buf_get_name(buf)
 	local is_chat = M.not_chat(buf, file_name) == nil

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -7,23 +7,23 @@
 local config = require("gp.config")
 
 local M = {
-	_Name = "Gp",                          -- plugin name
-	_state = {},                           -- table of state variables
-	agents = {},                           -- table of agents
-	cmd = {},                              -- default command functions
-	config = {},                           -- config variables
-	hooks = {},                            -- user defined command functions
-	defaults = require("gp.defaults"),     -- some useful defaults
+	_Name = "Gp", -- plugin name
+	_state = {}, -- table of state variables
+	agents = {}, -- table of agents
+	cmd = {}, -- default command functions
+	config = {}, -- config variables
+	hooks = {}, -- user defined command functions
+	defaults = require("gp.defaults"), -- some useful defaults
 	deprecator = require("gp.deprecator"), -- handle deprecated options
 	dispatcher = require("gp.dispatcher"), -- handle communication with LLM providers
-	helpers = require("gp.helper"),        -- helper functions
-	imager = require("gp.imager"),         -- image generation module
-	logger = require("gp.logger"),         -- logger module
-	render = require("gp.render"),         -- render module
-	spinner = require("gp.spinner"),       -- spinner module
-	tasker = require("gp.tasker"),         -- tasker module
-	vault = require("gp.vault"),           -- handles secrets
-	whisper = require("gp.whisper"),       -- whisper module
+	helpers = require("gp.helper"), -- helper functions
+	imager = require("gp.imager"), -- image generation module
+	logger = require("gp.logger"), -- logger module
+	render = require("gp.render"), -- render module
+	spinner = require("gp.spinner"), -- spinner module
+	tasker = require("gp.tasker"), -- tasker module
+	vault = require("gp.vault"), -- handles secrets
+	whisper = require("gp.whisper"), -- whisper module
 }
 
 --------------------------------------------------------------------------------
@@ -137,11 +137,11 @@ M.setup = function(opts)
 		elseif not agent.model or not agent.system_prompt then
 			M.logger.warning(
 				"Agent "
-				.. name
-				.. " is missing model or system_prompt\n"
-				.. "If you want to disable an agent, use: { name = '"
-				.. name
-				.. "', disable = true },"
+					.. name
+					.. " is missing model or system_prompt\n"
+					.. "If you want to disable an agent, use: { name = '"
+					.. name
+					.. "', disable = true },"
 			)
 			M.agents[name] = nil
 		end
@@ -282,9 +282,9 @@ end
 
 M.Target = {
 	rewrite = 0, -- for replacing the selection, range or the current line
-	append = 1,  -- for appending after the selection, range or the current line
+	append = 1, -- for appending after the selection, range or the current line
 	prepend = 2, -- for prepending before the selection, range or the current line
-	popup = 3,   -- for writing into the popup window
+	popup = 3, -- for writing into the popup window
 
 	-- for writing into a new buffer
 	---@param filetype nil | string # nil = same as the original buffer
@@ -378,8 +378,8 @@ M._toggle = {}
 
 M._toggle_kind = {
 	unknown = 0, -- unknown toggle
-	chat = 1,    -- chat toggle
-	popup = 2,   -- popup toggle
+	chat = 1, -- chat toggle
+	popup = 2, -- popup toggle
 	context = 3, -- context toggle
 }
 
@@ -387,13 +387,13 @@ M._toggle_kind = {
 ---@return boolean # true if toggle was closed
 M._toggle_close = function(kind)
 	if
-					M._toggle[kind]
-					and M._toggle[kind].win
-					and M._toggle[kind].buf
-					and M._toggle[kind].close
-					and vim.api.nvim_win_is_valid(M._toggle[kind].win)
-					and vim.api.nvim_buf_is_valid(M._toggle[kind].buf)
-					and vim.api.nvim_win_get_buf(M._toggle[kind].win) == M._toggle[kind].buf
+		M._toggle[kind]
+		and M._toggle[kind].win
+		and M._toggle[kind].buf
+		and M._toggle[kind].close
+		and vim.api.nvim_win_is_valid(M._toggle[kind].win)
+		and vim.api.nvim_buf_is_valid(M._toggle[kind].buf)
+		and vim.api.nvim_win_get_buf(M._toggle[kind].win) == M._toggle[kind].buf
 	then
 		if #vim.api.nvim_list_wins() == 1 then
 			M.logger.warning("Can't close the last window.")
@@ -609,10 +609,10 @@ end
 
 M.BufTarget = {
 	current = 0, -- current window
-	popup = 1,   -- popup window
-	split = 2,   -- split window
-	vsplit = 3,  -- vsplit window
-	tabnew = 4,  -- new tab
+	popup = 1, -- popup window
+	split = 2, -- split window
+	vsplit = 3, -- vsplit window
+	tabnew = 4, -- new tab
 }
 
 ---@param params table | string # table with args or string args
@@ -1233,7 +1233,7 @@ M.cmd.ChatFinder = function()
 	local command_buf, command_win, command_close, command_resize = M.render.popup(
 		nil,
 		"Search: <Tab>/<Shift+Tab>|navigate <Esc>|picker <C-c>|exit "
-		.. "<Enter>/<C-f>/<C-x>/<C-v>/<C-t>/<C-g>t|open/float/split/vsplit/tab/toggle",
+			.. "<Enter>/<C-f>/<C-x>/<C-v>/<C-t>/<C-g>t|open/float/split/vsplit/tab/toggle",
 		function(w, h)
 			return w - left - right, 1, h - bottom, left
 		end,

--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1546,6 +1546,58 @@ M.cmd.NextAgent = function()
 	set_agent(agent_list[1])
 end
 
+M.cmd.AgentSelect = function()
+	local buf = vim.api.nvim_get_current_buf()
+	local file_name = vim.api.nvim_buf_get_name(buf)
+	local is_chat = M.not_chat(buf, file_name) == nil
+	local current_agent, agent_list
+
+	if is_chat then
+		current_agent = M._state.chat_agent
+		agent_list = M._chat_agents
+	else
+		current_agent = M._state.command_agent
+		agent_list = M._command_agents
+	end
+
+	if #agent_list == 0 then
+		M.logger.warning("No agents available")
+		return
+	end
+
+	-- Create options with current agent highlighted
+	local options = {}
+	for _, agent_name in ipairs(agent_list) do
+		if agent_name == current_agent then
+			table.insert(options, agent_name .. " (current)")
+		else
+			table.insert(options, agent_name)
+		end
+	end
+
+	vim.ui.select(options, {
+		prompt = is_chat and "Select chat agent:" or "Select command agent:",
+		format_item = function(item)
+			return item
+		end,
+	}, function(choice)
+		if not choice then
+			return
+		end
+
+		-- Remove " (current)" suffix if present
+		local agent_name = choice:gsub(" %(current%)$", "")
+
+		if is_chat then
+			M.refresh_state({ chat_agent = agent_name })
+			M.logger.info("Chat agent: " .. M._state.chat_agent)
+		else
+			M.refresh_state({ command_agent = agent_name })
+			M.logger.info("Command agent: " .. M._state.command_agent)
+		end
+	end)
+end
+
 ---@param name string | nil
 ---@return table | nil # { cmd_prefix, name, model, system_prompt, provider}
 M.get_command_agent = function(name)


### PR DESCRIPTION
This PR adds the `:GpSelectAgent` command, providing a more intuitive way to switch between AI agents when you have multiple models configured.

### What's New
- **`:GpSelectAgent` command**: Opens a selection interface using `vim.ui.select` to choose from all available agents
- **Context-aware selection**: Automatically shows chat agents when in a chat buffer, command agents otherwise
- **Current agent highlighting**: The currently active agent is marked with "(current)" for easy identification
- **Telescope integration**: Works seamlessly with telescope.nvim if available, providing fuzzy search capabilities
- **Better UX for many models**: Instead of cycling through agents one by one with `:GpNextAgent`, users can now see all options and directly select their desired model

### Usage

Run `:GpSelectAgent` or use the default keybinding `<C-g>j` to open the agent selection interface. The command detects your current buffer context and presents the appropriate agent list.

<img width="916" height="419" alt="image" src="https://github.com/user-attachments/assets/8046aab3-da37-46ec-9184-b62859df19a0" />


This enhancement significantly improves the user experience when working with multiple AI models, making agent switching quick and intuitive.