### PR TITLE
Rename hosts.json to apps.json for Copilot secret configuration

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -44,7 +44,7 @@ local config = {
 			secret = {
 				"bash",
 				"-c",
-				"cat ~/.config/github-copilot/hosts.json | sed -e 's/.*oauth_token...//;s/\".*//'",
+				"cat ~/.config/github-copilot/apps.json | sed -e 's/.*oauth_token...//;s/\".*//'",
 			},
 		},
 		ollama = {


### PR DESCRIPTION
This PR updates the Copilot configuration to use `apps.json` instead of `hosts.json` for OAuth token extraction, restoring Copilot functionality in the `gp.nvim` plugin.