### PR TITLE
fix(anthropic): resolve parameter conflict with `claude-opus-4-1-20250805`

### DIFF
--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -155,8 +155,8 @@ D.prepare_payload = function(messages, model, provider)
 			messages = messages,
 			system = system,
 			max_tokens = model.max_tokens or 4096,
-			temperature = math.max(0, math.min(2, model.temperature or 1)),
-			top_p = math.max(0, math.min(1, model.top_p or 1)),
+			temperature = model.temperature and math.max(0, math.min(2, model.temperature)) or nil,
+			top_p = model.top_p and math.max(0, math.min(1, model.top_p)) or nil,
 		}
 		return payload
 	end


### PR DESCRIPTION
This fixes addresses a compatibility issue with Claude's latest model release, `claude-opus-4-1-20250805`.

This model version does not allow for sending along both the `temperature` and `top_p` parameter, it doesn't accept both simultaneously.  Previously, the dispatcher was constructing the payload with both, leading to potential errors or unexpected behavior when interacting with Claude.

This change ensures that the payload only includes `temperature` and `top_p` if the corresponding model arguments are provided. This gives users the option to use Sonnet with both parameters, and leaving `top_p` empty for Opus.

## Example configuration
**Sonnet agent**
```lua
{
    disable = false,
    name = "claude-sonnet",
    provider = "anthropic",
    chat = true,
    command = true,
    model = {
        model = "claude-sonnet-4-20250514",
        temperature = 0.8,
        top_p = 1
    },
    system_prompt = prompts["default"],
}
```

**Opus agent**
```lua
{
    disable = false,
    name = "claude-opus",
    provider = "anthropic",
    chat = true,
    command = true,
    model = {
        model = "claude-opus-4-1-20250805",
        temperature = 1
    },
    system_prompt = prompts["default"],
}
```