### PR TITLE
feat: Add native Ollama API support with "think" control

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -197,6 +197,19 @@ local config = {
 			system_prompt = "You are a general AI assistant.",
 		},
 		{
+			provider = "ollama",
+			name = "ChatQwen3-8B",
+			chat = true,
+			command = false,
+			-- string with model name or table with model name and parameters
+			model = {
+				model = "qwen3:8b",
+				think = false, -- toggle thinking in ollama's "thinkings" models
+			},
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = "You are a general AI assistant.",
+		},
+		{
 			provider = "lmstudio",
 			name = "ChatLMStudio",
 			chat = true,

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -49,7 +49,7 @@ local config = {
 		},
 		ollama = {
 			disable = true,
-			endpoint = "http://localhost:11434/v1/chat/completions",
+			endpoint = "http://localhost:11434/api/chat",
 			secret = "dummy_secret",
 		},
 		lmstudio = {

--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -161,6 +161,41 @@ D.prepare_payload = function(messages, model, provider)
 		return payload
 	end
 
+	if provider == "ollama" then
+		local payload = {
+			model = model.model,
+			stream = true,
+			messages = messages,
+		}
+
+		if model.think ~= nil then
+			payload.think = model.think
+		end
+
+		local options = {}
+		if model.temperature then
+			options.temperature = math.max(0, math.min(2, model.temperature))
+		end
+		if model.top_p then
+			options.top_p = math.max(0, math.min(1, model.top_p))
+		end
+		if model.min_p then
+			options.min_p = math.max(0, math.min(1, model.min_p))
+		end
+		if model.num_ctx then
+			options.num_ctx = model.num_ctx
+		end
+		if model.top_k then
+			options.top_k = model.top_k
+		end
+
+		if next(options) then
+			payload.options = options
+		end
+
+		return payload
+	end
+
 	local output = {
 		model = model.model,
 		stream = true,

--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -436,7 +436,6 @@ local query = function(buf, provider, payload, handler, on_exit, callback)
 		}
 		endpoint = render.template_replace(endpoint, "{{model}}", payload.model)
 	elseif provider == "ollama" then
-		-- Ollama local API typically doesn't require authentication
 		headers = {}
 	else -- default to openai compatible headers
 		headers = {

--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -270,6 +270,15 @@ local query = function(buf, provider, payload, handler, on_exit, callback)
 					end
 				end
 
+				if qt.provider == "ollama" then
+					if line:match('"message":') and line:match('"content":') then
+						local success, decoded = pcall(vim.json.decode, line)
+						if success and decoded.message and decoded.message.content then
+							content = decoded.message.content
+						end
+					end
+				end
+
 
 				if content and type(content) == "string" then
 					qt.response = qt.response .. content
@@ -391,6 +400,9 @@ local query = function(buf, provider, payload, handler, on_exit, callback)
 			"api-key: " .. bearer,
 		}
 		endpoint = render.template_replace(endpoint, "{{model}}", payload.model)
+	elseif provider == "ollama" then
+		-- Ollama local API typically doesn't require authentication
+		headers = {}
 	else -- default to openai compatible headers
 		headers = {
 			"-H",


### PR DESCRIPTION
While experimenting with Ollama's thinking control feature using `"think": false`, I discovered this parameter wasn't being respected. This is because this plugin currently uses Ollama's OpenAI-compatible endpoint (`/api/v1/chat/completions`) rather than the native API.

According to Ollama's documentation:

> "OpenAI compatibility is experimental and is subject to major adjustments including breaking changes. For fully-featured access to the Ollama API, see the Ollama [Python library](https://github.com/ollama/ollama-python), [JavaScript library](https://github.com/ollama/ollama-js) and [REST API](https://github.com/ollama/ollama/blob/main/docs/api.md).
>
> Ollama provides experimental compatibility with parts of the [OpenAI API](https://platform.openai.com/docs/api-reference) to help connect existing applications to Ollama."


According to Ollama's documentation, their OpenAI compatibility is "experimental and subject to major adjustments including breaking changes," while recommending their native API for "fully-featured access." This limitation prevents access to Ollama-specific features like thinking control, response formatting, and proper parameter structure.

This PR implements native Ollama API support to unlock these features while maintaining backward compatibility.

## Changes Made

• **Native API Response Parsing** - Added Ollama-specific streaming response handler for `{"message":{"content":"text"}}` format with robust error handling

• **Thinking Parameter Support** - Implemented `think` parameter control for models like Qwen, with example `ChatQwen3-8B` agent configuration

• **Proper Parameter Structure** - Refactored payload to follow Ollama API specification with parameters nested under `options` object (`temperature`, `top_p`, `min_p`, `num_ctx`, `top_k`)

• **Authentication Handling** - Removed unnecessary auth headers for Ollama's local API to prevent parameter interference

• **Configuration Updates** - Updated default Ollama endpoint to native `/api/chat` with example thinking-capable agent

## Benefits

Enables full Ollama feature access, proper API compliance, thinking control, and provides foundation for future Ollama-specific features while maintaining existing configuration compatibility.

**Usage Example:**
```lua
{
    provider = "ollama",
    name = "ChatQwen3-8B", 
    model = {
        model = "qwen3:8b",
        temperature = 0.7,
        think = false, -- Now works with native API
    },
}
```
