### PR TITLE
Add a support for Grok-4 from x.ai 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The following LLM providers are currently supported besides OpenAI:
 - [Perplexity.ai](https://www.perplexity.ai/pro) Pro users have $5/month free API credits available (the default PPLX agent uses Mixtral-8x7b).
 - [Anthropic](https://www.anthropic.com/api) to access Claude models, which currently outperform GPT-4 in some benchmarks.
 - [Google Gemini](https://ai.google.dev/) with a quite generous free range but some geo-restrictions (EU).
+- [x.ai](https://x.ai/api) to access Grok-4 with pre-paid credit plans (No free credit available at this moment).
 - Any other "OpenAI chat/completions" compatible endpoint (Azure, LM Studio, etc.)
 
 Below is an example of the relevant configuration part enabling some of these. The `secret` field has the same capabilities as `openai_api_key` (which is still supported for compatibility).
@@ -170,6 +171,11 @@ Below is an example of the relevant configuration part enabling some of these. T
 		anthropic = {
 			endpoint = "https://api.anthropic.com/v1/messages",
 			secret = os.getenv("ANTHROPIC_API_KEY"),
+		},
+
+		xai = {
+			endpoint = "https://api.x.ai/v1/chat/completions",
+			secret = os.getenv("XAI_API_KEY"),
 		},
 	},
 ```

--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -72,6 +72,11 @@ local config = {
 			endpoint = "https://api.anthropic.com/v1/messages",
 			secret = os.getenv("ANTHROPIC_API_KEY"),
 		},
+		xai = {
+			disable = true,
+			endpoint = "https://api.x.ai/v1/chat/completions",
+			secret = os.getenv("XAI_API_KEY"),
+		},
 	},
 
 	-- prefix for all commands
@@ -308,6 +313,15 @@ local config = {
 			command = true,
 			-- string with model name or table with model name and parameters
 			model = { model = "claude-3-5-haiku-latest", temperature = 0.8, top_p = 1 },
+			system_prompt = require("gp.defaults").code_system_prompt,
+		},
+		{
+			provider = "xai",
+			name = "Grok-4",
+			chat = false,
+			command = true,
+			-- string with model name or table with model name and parameters
+			model = { model = "grok-4-latest", temperature = 0 },
 			system_prompt = require("gp.defaults").code_system_prompt,
 		},
 		{

--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -193,6 +193,41 @@ D.prepare_payload = function(messages, model, provider)
 		return payload
 	end
 
+	if provider == "ollama" then
+		local payload = {
+			model = model.model,
+			stream = true,
+			messages = messages,
+		}
+
+		if model.think ~= nil then
+			payload.think = model.think
+		end
+
+		local options = {}
+		if model.temperature then
+			options.temperature = math.max(0, math.min(2, model.temperature))
+		end
+		if model.top_p then
+			options.top_p = math.max(0, math.min(1, model.top_p))
+		end
+		if model.min_p then
+			options.min_p = math.max(0, math.min(1, model.min_p))
+		end
+		if model.num_ctx then
+			options.num_ctx = model.num_ctx
+		end
+		if model.top_k then
+			options.top_k = model.top_k
+		end
+
+		if next(options) then
+			payload.options = options
+		end
+
+		return payload
+	end
+
 	local output = {
 		model = model.model,
 		stream = true,

--- a/lua/gp/dispatcher.lua
+++ b/lua/gp/dispatcher.lua
@@ -476,8 +476,6 @@ local query = function(buf, provider, payload, handler, on_exit, callback)
 			"api-key: " .. bearer,
 		}
 		endpoint = render.template_replace(endpoint, "{{model}}", payload.model)
-	elseif provider == "ollama" then
-		headers = {}
 	elseif provider == "xai" then
 		-- currently xai only uses bearer token for authentication.
 		-- since I cannot sure its going to be that way for long time
@@ -486,6 +484,8 @@ local query = function(buf, provider, payload, handler, on_exit, callback)
 			"-H",
 			"Authorization: Bearer " .. bearer,
 		}
+	elseif provider == "ollama" then
+		headers = {}
 	else -- default to openai compatible headers
 		headers = {
 			"-H",


### PR DESCRIPTION
# Summary

* Adding a support for Grok-4 model by adding "xai" as a provider

# Changes

* Adding "xai" provider
* Adding "Grok-4" model (provider: xai, model-id: "grok-4-latest")

# Added Config

```lua
{
    provider = "xai",
    name = "Grok-4",
    chat = false,
    command = true,
    -- string with model name or table with model name and parameters
    model = { model = "grok-4-latest", temperature = 0 },
    system_prompt = require("gp.defaults").code_system_prompt,
},
```

# Note

* the response has been tested for some coding assignments.
* **The reponse time is very slow (approx 1-2 seconds),** compared to other model provider.  
* the temperature parameter configuration was brought from the default curl example that x.ai provided.
* the pricing of grok-4 is  input for $3/mil, output for $15/mil.
* If requested, I can add grok-3 (same pricing, but if you want to) and grok-3 mini (more cheaper) in configuration. 