### PR TITLE
adding support for openai responses API

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -33,6 +33,11 @@ local config = {
 			endpoint = "https://api.openai.com/v1/chat/completions",
 			-- secret = os.getenv("OPENAI_API_KEY"),
 		},
+		openai_resp = {
+			disable = false,
+			endpoint = "https://api.openai.com/v1/responses",
+			secret = os.getenv("OPENAI_API_KEY"),
+		},
 		azure = {
 			disable = true,
 			endpoint = "https://$URL.openai.azure.com/openai/deployments/{{model}}/chat/completions",
@@ -59,7 +64,8 @@ local config = {
 		},
 		googleai = {
 			disable = true,
-			endpoint = "https://generativelanguage.googleapis.com/v1beta/models/{{model}}:streamGenerateContent?key={{secret}}",
+			endpoint =
+			"https://generativelanguage.googleapis.com/v1beta/models/{{model}}:streamGenerateContent?key={{secret}}",
 			secret = os.getenv("GOOGLEAI_API_KEY"),
 		},
 		pplx = {
@@ -104,6 +110,16 @@ local config = {
 		},
 		{
 			name = "ChatGPT4o",
+			chat = true,
+			command = false,
+			-- string with model name or table with model name and parameters
+			model = { model = "gpt-4o", temperature = 1.1, top_p = 1 },
+			-- system prompt (use this to specify the persona/role of the AI)
+			system_prompt = require("gp.defaults").chat_system_prompt,
+		},
+		{
+			name = "ChatGPT4o_new",
+			provider = "openai_resp",
 			chat = true,
 			command = false,
 			-- string with model name or table with model name and parameters
@@ -367,6 +383,9 @@ local config = {
 	-- how to display GpChatToggle or GpContext
 	---@type "popup" | "split" | "vsplit" | "tabnew"
 	toggle_target = "vsplit",
+
+	-- utilize tooling made available in the openai responses API, see openAI's online documentation
+	openai_resp_tools = {},
 
 	-- styling for chatfinder
 	---@type "single" | "double" | "rounded" | "solid" | "shadow" | "none"

--- a/lua/gp/render.lua
+++ b/lua/gp/render.lua
@@ -14,7 +14,6 @@ local M = {}
 ---@return string # returns rendered template with specified key replaced by value
 M.template_replace = function(template, key, value)
 	value = value or ""
-
 	if type(value) == "table" then
 		value = table.concat(value, "\n")
 	end

--- a/lua/gp/vault.lua
+++ b/lua/gp/vault.lua
@@ -104,7 +104,8 @@ V.resolve_secret = function(name, secret, callback)
 			if code == 0 then
 				local content = stdout_data:match("^%s*(.-)%s*$")
 				if not string.match(content, "%S") then
-					logger.warning("vault resolver got empty response for " .. name .. " secret command " .. vim.inspect(secret))
+					logger.warning("vault resolver got empty response for " ..
+						name .. " secret command " .. vim.inspect(secret))
 					return
 				end
 				secrets[name] = content
@@ -112,17 +113,17 @@ V.resolve_secret = function(name, secret, callback)
 			else
 				logger.warning(
 					"vault resolver for "
-						.. name
-						.. "secret command "
-						.. vim.inspect(secret)
-						.. " failed:\ncode: "
-						.. code
-						.. ", signal: "
-						.. signal
-						.. "\nstdout: "
-						.. stdout_data
-						.. "\nstderr: "
-						.. stderr_data
+					.. name
+					.. "secret command "
+					.. vim.inspect(secret)
+					.. " failed:\ncode: "
+					.. code
+					.. ", signal: "
+					.. signal
+					.. "\nstdout: "
+					.. stdout_data
+					.. "\nstderr: "
+					.. stderr_data
 				)
 			end
 		end)


### PR DESCRIPTION
This changeset aims to passively add support for [the responses openai REST API](https://platform.openai.com/docs/api-reference/responses). The [completion API currently used by gp.nvim is deprecated](https://platform.openai.com/docs/api-reference/completions/create).

One highlight of the new API is the "web crawler support" via the tools header. You can ask the agent for "what's the weather today in Chicago?" and it will be able to answer.

Open to any feedback!
