### PR TITLE
fix: fix topic line sometimes coming back as empty string

### DIFF
--- a/lua/gp/init.lua
+++ b/lua/gp/init.lua
@@ -1173,7 +1173,8 @@ M.chat_respond = function(params)
 					topic_handler,
 					vim.schedule_wrap(function()
 						-- get topic from invisible buffer
-						local topic = vim.api.nvim_buf_get_lines(topic_buf, 0, -1, false)[1]
+						local topic_buf_lines = vim.api.nvim_buf_get_lines(topic_buf, 0, -1, false)
+						local topic = table.concat(topic_buf_lines)
 						-- close invisible buffer
 						vim.api.nvim_buf_delete(topic_buf, { force = true })
 						-- strip whitespace from ends of topic


### PR DESCRIPTION
Certain models may add empty lines around the response. The way the string was extracted, we could get empty strings, depending on the model used. This concatenates the model response lines resulting in a single line.